### PR TITLE
Fixes failing tests and updates license headers in files

### DIFF
--- a/src/plugins/custom_import_map/public/components/vector_upload_options.test.tsx
+++ b/src/plugins/custom_import_map/public/components/vector_upload_options.test.tsx
@@ -283,7 +283,7 @@ describe('vector_upload_options', () => {
       ],
     };
     const jsonDataArray = [];
-    const max = 500000;
+    const max = 100000;
     for (; jsonDataArray.push(jsonData) < max; );
     const str = JSON.stringify(jsonDataArray);
     const blob = new Blob([str]);

--- a/src/plugins/custom_import_map/public/index.ts
+++ b/src/plugins/custom_import_map/public/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { CustomImportMapPlugin } from './plugin';
 
 // This exports static code and TypeScript types,

--- a/src/plugins/custom_import_map/public/plugin.tsx
+++ b/src/plugins/custom_import_map/public/plugin.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
 import { i18n } from '@osd/i18n';
 import { CoreSetup, CoreStart, Plugin } from '../../../src/core/public';

--- a/src/plugins/custom_import_map/public/services.ts
+++ b/src/plugins/custom_import_map/public/services.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const postGeojson = async (requestBody: any, http: any) => {
+import { CoreStart } from "../../../src/core/public";
+
+export const postGeojson = async (requestBody: any, http: CoreStart['http']) => {
   try {
     const response = await http.post('../api/custom_import_map/_upload', {
       body: requestBody,
@@ -14,7 +16,7 @@ export const postGeojson = async (requestBody: any, http: any) => {
   }
 };
 
-export const getIndex = async (indexName: string, http: any) => {
+export const getIndex = async (indexName: string, http: CoreStart['http']) => {
   try {
     const response = await http.post('../api/custom_import_map/_indices', {
       body: JSON.stringify({

--- a/src/plugins/custom_import_map/public/types.ts
+++ b/src/plugins/custom_import_map/public/types.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
 import { RegionMapPluginSetup } from '../../../src/plugins/region_map/public';
 

--- a/src/plugins/custom_import_map/server/index.ts
+++ b/src/plugins/custom_import_map/server/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { PluginInitializerContext } from '../../../src/core/server';
 import { CustomImportMapPlugin } from './plugin';
 

--- a/src/plugins/custom_import_map/server/plugin.ts
+++ b/src/plugins/custom_import_map/server/plugin.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
   PluginInitializerContext,
   CoreSetup,

--- a/src/plugins/custom_import_map/server/types.ts
+++ b/src/plugins/custom_import_map/server/types.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CustomImportMapPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
An intermittent failure is seen in running the tests via github actions - `FATAL ERROR: MarkCompactCollector: young object promotion failed Allocation failed - JavaScript heap out of memory` eg. https://github.com/opensearch-project/dashboards-maps/runs/6872023951?check_suite_focus=true. This PR helps in resolving the issue and also updates license headers in few files that were missing from the initial commit.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
