### PR TITLE
Introduces refresh option to update the custom vector map list

### DIFF
--- a/src/plugins/custom_import_map/public/components/__snapshots__/vector_upload_options.test.tsx.snap
+++ b/src/plugins/custom_import_map/public/components/__snapshots__/vector_upload_options.test.tsx.snap
@@ -210,6 +210,11 @@ Object {
                   </span>
                 </button>
               </div>
+              <div
+                aria-label="medium-spacer"
+                class="euiSpacer euiSpacer--m"
+              />
+              <div />
             </div>
           </div>
         </div>
@@ -422,6 +427,11 @@ Object {
                 </span>
               </button>
             </div>
+            <div
+              aria-label="medium-spacer"
+              class="euiSpacer euiSpacer--m"
+            />
+            <div />
           </div>
         </div>
       </div>

--- a/src/plugins/custom_import_map/public/components/vector_upload_options.test.tsx
+++ b/src/plugins/custom_import_map/public/components/vector_upload_options.test.tsx
@@ -194,6 +194,8 @@ describe('vector_upload_options', () => {
     await waitFor(() => {
       fireEvent.click(button);
     });
+    const customerCalloutDiv = screen.getByTestId('customerCallout');
+    expect(customerCalloutDiv).toBeTruthy();
   });
 
   it('renders the VectorUploadOptions component when we have partial failures during indexing', async () => {
@@ -209,6 +211,8 @@ describe('vector_upload_options', () => {
     await waitFor(() => {
       fireEvent.click(button);
     });
+    const customerCalloutDiv = screen.getByTestId('customerCallout');
+    expect(customerCalloutDiv).toBeTruthy();
   });
 
   it('renders the VectorUploadOptions component when all the documents fail to index', async () => {

--- a/src/plugins/custom_import_map/public/components/vector_upload_options.tsx
+++ b/src/plugins/custom_import_map/public/components/vector_upload_options.tsx
@@ -7,6 +7,7 @@ import './vector_upload_options.scss';
 import React, { useState } from 'react';
 import {
   EuiButton,
+  EuiCallOut,
   EuiFilePicker,
   EuiFlexItem,
   EuiFlexGroup,
@@ -43,6 +44,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
   const [value, setValue] = useState('');
   const [isLoading, setLoading] = useState(false);
   const [fileContent, setFileContent] = useState();
+  const [showCustomerCallout, setCustomerCallout] = useState(false);
 
   const onTextChange = (e) => {
     setValue(e.target.value);
@@ -173,6 +175,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
       notifications.toasts.addSuccess(
         'Successfully added ' + successfullyIndexedRecordCount + ' features to ' + indexName
       );
+      setCustomerCallout(true);
       return;
     }
 
@@ -203,6 +206,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
           </div>
         ),
       });
+      setCustomerCallout(true);
     }
 
     if (successfullyIndexedRecordCount === 0) {
@@ -237,6 +241,10 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
     } else {
       notifications.toasts.addWarning('Map name ' + indexName + ' already exists.');
     }
+  };
+
+  const refresh = () => {
+    window.location.reload();
   };
 
   return (
@@ -328,6 +336,25 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
             Import file
           </EuiButton>
         </div>
+        <EuiSpacer size="m" aria-label="medium-spacer" />
+
+        {showCustomerCallout ? (
+          <div
+            className="customerCallout"
+            id="customerCallout"
+            aria-label="hit-refresh-div"
+            data-testid="customerCallout"
+          >
+            <EuiCallOut title="Proceed with caution!" color="warning" iconType="help">
+              <p>Hit refresh before moving to custom map visualization.</p>
+              <EuiButton onClick={refresh} color="warning">
+                Refresh
+              </EuiButton>
+            </EuiCallOut>
+          </div>
+        ) : (
+          <div />
+        )}
       </EuiCard>
     </div>
   );

--- a/src/plugins/custom_import_map/test/jest.config.js
+++ b/src/plugins/custom_import_map/test/jest.config.js
@@ -14,18 +14,15 @@ module.exports = {
   modulePaths: ['node_modules', `../../node_modules`],
   coverageDirectory: './coverage',
   moduleNameMapper: {
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/test/mocks/styleMock.js',
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '<rootDir>/test/mocks/styleMock.js',
     '\\.(css|less|scss)$': '<rootDir>/test/mocks/styleMock.js',
     '^ui/(.*)': '<rootDir>/../../src/legacy/ui/public/$1/',
   },
   snapshotSerializers: ['../../../../node_modules/enzyme-to-json/serializer'],
   coverageReporters: ['lcov', 'text', 'cobertura'],
   testMatch: ['**/*.test.js', '**/*.test.ts', '**/*.test.tsx'],
-  coveragePathIgnorePatterns: [
-    '<rootDir>/build/',
-    '<rootDir>/node_modules/',
-    '<rootDir>/test/'
-  ],
+  coveragePathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/', '<rootDir>/test/'],
   clearMocks: true,
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
   modulePathIgnorePatterns: [],


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
The PR adds customer callout to refresh the page before visualizing the uploaded custom vector map.
The callout is seen right after the geoJSON file is imported by the user when all the features that are part of the geoJSON file are indexed completely or partially. In case of any other failure, the callout won't be shown - as there is no change in the custom vector map list.

<img width="408" alt="Screen Shot 2022-06-27 at 9 05 07 AM" src="https://user-images.githubusercontent.com/9303427/175990412-c56d1938-3951-4b2f-8927-5b271eebc6c3.png">

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
