### PR TITLE
Fixes issue with file validation and danger toast messages

### DIFF
--- a/src/plugins/custom_import_map/common/constants/shared.ts
+++ b/src/plugins/custom_import_map/common/constants/shared.ts
@@ -5,6 +5,7 @@
 
 import { fromMBtoBytes } from '../util';
 
+export const ALLOWED_FILE_EXTENSIONS = ['.json', '.geojson'];
 export const BASE_NODE_API_PATH = '/_plugins/geospatial';
 export const UPLOAD_GEOJSON_API_PATH = `${BASE_NODE_API_PATH}/geojson/_upload`;
 export const MAX_FILE_PAYLOAD_SIZE_IN_MB = 25;

--- a/src/plugins/custom_import_map/common/index.ts
+++ b/src/plugins/custom_import_map/common/index.ts
@@ -5,6 +5,7 @@
 
 import { fromMBtoBytes } from './util';
 import {
+  ALLOWED_FILE_EXTENSIONS,
   MAX_FILE_PAYLOAD_SIZE,
   MAX_FILE_PAYLOAD_SIZE_IN_MB,
   PLUGIN_ID,
@@ -13,6 +14,7 @@ import {
 
 export {
   fromMBtoBytes,
+  ALLOWED_FILE_EXTENSIONS,
   MAX_FILE_PAYLOAD_SIZE,
   MAX_FILE_PAYLOAD_SIZE_IN_MB,
   PLUGIN_ID,

--- a/src/plugins/custom_import_map/public/components/__snapshots__/vector_upload_options.test.tsx.snap
+++ b/src/plugins/custom_import_map/public/components/__snapshots__/vector_upload_options.test.tsx.snap
@@ -197,7 +197,7 @@ Object {
                   aria-label="import-file-button"
                   class="euiButton euiButton--primary euiButton--fill"
                   id="submitButton"
-                  type="submit"
+                  type="button"
                 >
                   <span
                     class="euiButtonContent euiButton__content"
@@ -409,7 +409,7 @@ Object {
                 aria-label="import-file-button"
                 class="euiButton euiButton--primary euiButton--fill"
                 id="submitButton"
-                type="submit"
+                type="button"
               >
                 <span
                   class="euiButtonContent euiButton__content"

--- a/src/plugins/custom_import_map/public/components/vector_upload_options.test.tsx
+++ b/src/plugins/custom_import_map/public/components/vector_upload_options.test.tsx
@@ -330,6 +330,19 @@ describe('vector_upload_options', () => {
     });
   });
 
+  it('renders danger toast as file format is not geojson or json', async () => {
+    const { getByTestId } = render(<VectorUploadOptions {...props} />);
+    const indexName = screen.getByTestId('customIndex');
+    fireEvent.change(indexName, { target: { value: 'sample' } });
+    const uploader = getByTestId('filePicker');
+    const file = new File([], 'sample.txt', { type: 'text/plain' });
+    File.prototype.text = jest.fn().mockResolvedValueOnce(JSON.stringify([]));
+    await fireEvent.change(uploader, {
+      target: { files: [file] },
+    });
+    await expect(uploader.files[0].name).toBe('sample.txt');
+  });
+
   it('renders the VectorUploadOptions component when uploaded file size is >25 MB', async () => {
     const { getByTestId } = render(<VectorUploadOptions {...props} />);
     const indexName = screen.getByTestId('customIndex');


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
- Fixes issue that can be seen in case we drag any non geojson/json file into file import box.

If we drag any non json file, following toast is displayed:

<img width="345" alt="Screen Shot 2022-07-20 at 3 08 24 PM" src="https://user-images.githubusercontent.com/9303427/180091003-7229a9c1-1201-48cc-a292-3af1922a0ca1.png">

- Improves danger toast messaging in case random json file is imported.

In case we upload non-geojson format files, following toasts are displayed to the user:

<img width="352" alt="Screen Shot 2022-07-20 at 1 18 19 PM" src="https://user-images.githubusercontent.com/9303427/180091038-69ac2cec-f8bb-4bf2-8f2b-4f9ba5bbdcab.png">

<img width="341" alt="Screen Shot 2022-07-20 at 1 13 31 PM" src="https://user-images.githubusercontent.com/9303427/180091024-28892ead-2c51-44e6-998b-ecaf8ee49a77.png">


### Issues Resolved
- File validation to kick in when random files are being dragged into the file import box.
- Make error message more intuitive in case random json file is imported.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
