### PR TITLE
adds changes for releasing plugin with OSD as part of 2.2 release

### DIFF
--- a/.github/workflows/unit-tests-workflow-for-customImportMap.yml
+++ b/.github/workflows/unit-tests-workflow-for-customImportMap.yml
@@ -2,10 +2,10 @@ name: Unit tests workflow
 on:
   push:
     branches:
-      - main
+      - 2.x
   pull_request:
     branches:
-      - main
+      - 2.x
 
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.0'
@@ -29,7 +29,6 @@ jobs:
         run: |
           echo "::set-output name=node_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.node).match(/[.0-9]+/)[0]")"
           echo "::set-output name=yarn_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
-
       - name: Setup node
         uses: actions/setup-node@v1
         with:
@@ -41,19 +40,16 @@ jobs:
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
-
-      - name: Move src/plugins/custom_import_map to Plugins Dir
-        run: mv src/ OpenSearch-Dashboards/plugins/
+      - name: Move custom_import_map to Plugins Dir
+        run: mv src/plugins/custom_import_map OpenSearch-Dashboards/plugins/custom_import_map
 
       - name: Bootstrap plugin/opensearch-dashboards
         run: |
-          cd OpenSearch-Dashboards/plugins/src/plugins/custom_import_map
+          cd OpenSearch-Dashboards/plugins/custom_import_map
           yarn osd bootstrap
-
       - name: Run tests
         run: |
-          cd OpenSearch-Dashboards/plugins/src/plugins/custom_import_map
+          cd OpenSearch-Dashboards/plugins/custom_import_map
           yarn run test:jest --coverage
-
       - name: Uploads coverage
         uses: codecov/codecov-action@v1

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -33,7 +33,8 @@ echo 'src/plugins/custom_import_map/*' >> .git/info/sparse-checkout
 git config core.sparseCheckout true
 git checkout main
 ```
-6. Run `yarn osd bootstrap` inside `OpenSearch-Dashboards/plugins/src/plugins/custom_import_map`.
+6. Retain only `custom_import_map` directory within plugins and remove `src/plugins` from the path.
+6. Run `yarn osd bootstrap` inside `OpenSearch-Dashboards/plugins/custom_import_map`.
 
 Ultimately, your directory structure should look like this:
 
@@ -41,12 +42,12 @@ Ultimately, your directory structure should look like this:
 .
 ├── OpenSearch-Dashboards
 │   └── plugins
-│       └── src/plugins/custom_import_map
+│       └── custom_import_map
 ```
 
 ### Run
 
-From OpenSearch-Dashbaords repo (root folder), run the following command -
+From OpenSearch-Dashboards repo (root folder), run the following command -
 - `yarn start`
 
   Starts OpenSearch Dashboards and includes this plugin. OpenSearch Dashboards will be available on `localhost:5601`.

--- a/src/plugins/custom_import_map/package.json
+++ b/src/plugins/custom_import_map/package.json
@@ -3,12 +3,12 @@
   "version": "2.2.0.0",
   "scripts": {
     "build": "yarn plugin-helpers build",
-    "plugin-helpers": "node ../../../../scripts/plugin_helpers",
-    "osd": "node ../../../../scripts/osd",
+    "plugin-helpers": "node ../../scripts/plugin_helpers",
+    "osd": "node ../../scripts/osd",
     "lint": "yarn run lint:es && yarn run lint:style",
-    "lint:es": "node ../../../../scripts/eslint",
-    "lint:style": "node ../../../../scripts/stylelint",
-    "test:jest": "TZ=UTC ../../../../node_modules/.bin/jest --config ./test/jest.config.js"
+    "lint:es": "node ../../scripts/eslint",
+    "lint:style": "node ../../scripts/stylelint",
+    "test:jest": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js"
   },
   "husky": {
     "hooks": {

--- a/src/plugins/custom_import_map/public/components/vector_upload_options.test.tsx
+++ b/src/plugins/custom_import_map/public/components/vector_upload_options.test.tsx
@@ -10,7 +10,7 @@ import { fireEvent } from '@testing-library/dom';
 import '@testing-library/jest-dom';
 import * as serviceApiCalls from '../services';
 
-jest.mock('../../../../../../src/plugins/opensearch_dashboards_react/public', () => ({
+jest.mock('../../../../src/plugins/opensearch_dashboards_react/public', () => ({
   useOpenSearchDashboards: jest.fn().mockReturnValue({
     services: {
       http: {

--- a/src/plugins/custom_import_map/public/components/vector_upload_options.tsx
+++ b/src/plugins/custom_import_map/public/components/vector_upload_options.tsx
@@ -29,8 +29,8 @@ import {
 import {
   toMountPoint,
   useOpenSearchDashboards,
-} from '../../../../../../src/plugins/opensearch_dashboards_react/public';
-import { RegionMapOptionsProps } from '../../../../../../src/plugins/region_map/public';
+} from '../../../../src/plugins/opensearch_dashboards_react/public';
+import { RegionMapOptionsProps } from '../../../../src/plugins/region_map/public';
 
 const VectorUploadOptions = (props: RegionMapOptionsProps) => {
   const opensearchDashboards = useOpenSearchDashboards();

--- a/src/plugins/custom_import_map/public/plugin.tsx
+++ b/src/plugins/custom_import_map/public/plugin.tsx
@@ -5,13 +5,13 @@
 
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { CoreSetup, CoreStart, Plugin } from '../../../../../src/core/public';
+import { CoreSetup, CoreStart, Plugin } from '../../../src/core/public';
 import {
   CustomImportMapPluginSetup,
   CustomImportMapPluginStart,
   AppPluginSetupDependencies,
 } from './types';
-import { RegionMapVisualizationDependencies } from '../../../../../src/plugins/region_map/public';
+import { RegionMapVisualizationDependencies } from '../../../src/plugins/region_map/public';
 import { VectorUploadOptions } from './components/vector_upload_options';
 
 export class CustomImportMapPlugin

--- a/src/plugins/custom_import_map/public/services.ts
+++ b/src/plugins/custom_import_map/public/services.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CoreStart } from '../../../../../src/core/public';
+import { CoreStart } from '../../../src/core/public';
 
 export const postGeojson = async (requestBody: any, http: CoreStart['http']) => {
   try {

--- a/src/plugins/custom_import_map/public/types.ts
+++ b/src/plugins/custom_import_map/public/types.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NavigationPublicPluginStart } from '../../../../../src/plugins/navigation/public';
-import { RegionMapPluginSetup } from '../../../../../src/plugins/region_map/public';
+import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+import { RegionMapPluginSetup } from '../../../src/plugins/region_map/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CustomImportMapPluginSetup {}

--- a/src/plugins/custom_import_map/server/index.ts
+++ b/src/plugins/custom_import_map/server/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PluginInitializerContext } from '../../../../../src/core/server';
+import { PluginInitializerContext } from '../../../src/core/server';
 import { CustomImportMapPlugin } from './plugin';
 
 // This exports static code and TypeScript types,

--- a/src/plugins/custom_import_map/server/plugin.ts
+++ b/src/plugins/custom_import_map/server/plugin.ts
@@ -10,7 +10,7 @@ import {
   CoreStart,
   Plugin,
   Logger,
-} from '../../../../../src/core/server';
+} from '../../../src/core/server';
 
 import { CustomImportMapPluginSetup, CustomImportMapPluginStart } from './types';
 import { createGeospatialCluster } from './clusters';

--- a/src/plugins/custom_import_map/test/jest.config.js
+++ b/src/plugins/custom_import_map/test/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
     '\\.(css|less|scss)$': '<rootDir>/test/mocks/styleMock.js',
     '^ui/(.*)': '<rootDir>/../../src/legacy/ui/public/$1/',
   },
-  snapshotSerializers: ['../../../../node_modules/enzyme-to-json/serializer'],
+  snapshotSerializers: ['../../node_modules/enzyme-to-json/serializer'],
   coverageReporters: ['lcov', 'text', 'cobertura'],
   testMatch: ['**/*.test.js', '**/*.test.ts', '**/*.test.tsx'],
   coveragePathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/', '<rootDir>/test/'],


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
- Modifies path references so that `src/plugins` can be removed while adding `custom_import_map` plugin to OSD

- Successfully ran the following commands: 
  - `yarn start` and tested out that the functionality works as expected
  - `yarn run test:jest --coverage --coverageDirectory=. -u` 
  - `yarn plugin-helpers build --opensearch-dashboards-version=2.2.0.0`
      
      ```
      yarn run v1.22.18
      warning package.json: No license field
      $ node ../../scripts/plugin_helpers build --opensearch-dashboards-version=2.2.0.0
      info deleting the build and target directories
      info running @osd/optimizer
     │ info initialized, 0 bundles cached
     │ info starting worker [1 bundle]
     │ succ 1 bundles compiled successfully after 21 sec
     info copying assets from `public/assets` to build
     info copying server source into the build and converting with babel
     info running yarn to install dependencies
     info compressing plugin into [customImportMap-2.2.0.0.zip]
      ```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
