### PR TITLE
Adds dashboards as suffix to plugin name

### DIFF
--- a/src/plugins/custom_import_map/opensearch_dashboards.json
+++ b/src/plugins/custom_import_map/opensearch_dashboards.json
@@ -1,5 +1,5 @@
 {
-    "id": "customImportMap",
+    "id": "customImportMapDashboards",
     "version": "2.2.0.0",
     "opensearchDashboardsVersion": "2.2.0",
     "server": true,

--- a/src/plugins/custom_import_map/package.json
+++ b/src/plugins/custom_import_map/package.json
@@ -1,6 +1,10 @@
 {
   "name": "customImportMap",
   "version": "2.2.0.0",
+  "license": "Apache-2.0",
+  "config": {
+    "id": "customImportMapDashboards"
+  },
   "scripts": {
     "build": "yarn plugin-helpers build",
     "plugin-helpers": "node ../../scripts/plugin_helpers",
@@ -8,8 +12,10 @@
     "lint": "yarn run lint:es && yarn run lint:style",
     "lint:es": "node ../../scripts/eslint",
     "lint:style": "node ../../scripts/stylelint",
-    "test:jest": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js"
-  },
+    "test:jest": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",
+    "postbuild": "echo Renaming build artifact to [$npm_package_config_id-$npm_package_version.zip] && mv build/$npm_package_config_id*.zip build/$npm_package_config_id-$npm_package_version.zip",
+    "opensearch": "node ../../scripts/opensearch"
+},
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/src/plugins/custom_import_map/test/jest.config.js
+++ b/src/plugins/custom_import_map/test/jest.config.js
@@ -25,6 +25,6 @@ module.exports = {
   coveragePathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/', '<rootDir>/test/'],
   clearMocks: true,
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
-  modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ['customImportMapDashboards'],
   testEnvironment: 'jest-environment-jsdom',
 };


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
- To remain consistent with the other dashboards plugins, added suffix to plugin name
- Also, added missing properties in package.json


Tested building the plugin zip -

```
yarn build
yarn run v1.22.18
$ yarn plugin-helpers build
$ node ../../scripts/plugin_helpers build
 info deleting the build and target directories
 info running @osd/optimizer
 │ info initialized, 0 bundles cached
 │ info starting worker [1 bundle]
 │ succ 1 bundles compiled successfully after 34.7 sec
 info copying assets from `public/assets` to build
 info copying server source into the build and converting with babel
 info running yarn to install dependencies
 info compressing plugin into [customImportMapDashboards-2.2.0.zip]
✨  Done in 44.34s.
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
