### PR TITLE
adds fix for running cypress tests in 2.3 branch

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: geospatial
           repository: opensearch-project/geospatial
-          ref: '2.2'
+          ref: '2.3'
       - name: Run Opensearch with plugin
         run: |
           cd geospatial


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description
- Changes geospatial plugin branch to 2.3 to fix failure seen on running cypress tests.

Workflow failure can be found here: https://github.com/opensearch-project/dashboards-maps/runs/8257005866?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
