### PR TITLE
Update maps vector tile service url

### DIFF
--- a/src/plugins/maps_dashboards/common/index.ts
+++ b/src/plugins/maps_dashboards/common/index.ts
@@ -6,9 +6,7 @@
 export const PLUGIN_ID = 'maps-dashboards';
 export const PLUGIN_NAME = 'Maps';
 
-// This style URL is only used for development, will replace with production vector tile service url.
-export const MAP_VECTOR_TILE_URL =
-  'https://dldbnqfps17cd.cloudfront.net/styles/basic-preview/compressedstyle.json';
+export const MAP_VECTOR_TILE_URL = 'https://tiles.maps.opensearch.org/styles/basic.json';
 
 // Starting position [lng, lat] and zoom
 export const MAP_INITIAL_STATE = {


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Since OpenSearch maps service vector tiles service are ready to use with basic style, updating maps vector tile service url in this PR.

### Issues Resolved
Closes https://github.com/opensearch-project/dashboards-maps/issues/57

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
