### PR TITLE
[Backport 2.4] Add window and mac platform to run unit test (#74)

### DIFF
--- a/.github/workflows/unit-tests-workflow-for-customImportMap.yml
+++ b/.github/workflows/unit-tests-workflow-for-customImportMap.yml
@@ -2,20 +2,37 @@ name: Unit tests workflow
 on:
   push:
     branches:
-      - 2.x
+      - "*"
+      - "feature/**"
+    paths:
+      - src/plugins/custom_import_map/**
+      - .github/workflows/unit-tests-workflow-for-customImportMap.yml
   pull_request:
     branches:
-      - 2.x
+      - "*"
+      - "feature/**"
+    paths:
+      - src/plugins/custom_import_map/**
+      - .github/workflows/unit-tests-workflow-for-customImportMap.yml
 
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.0'
 jobs:
   tests:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
     name: Run unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Plugin
         uses: actions/checkout@v2
+
+      # Enable longer filenames for windows
+      - name: Enable longer filenames
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: git config --system core.longpaths true
 
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
@@ -47,7 +64,7 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/custom_import_map
           yarn osd bootstrap
-      - name: Run tests
+      - name: Run tests with coverage
         run: |
           cd OpenSearch-Dashboards/plugins/custom_import_map
           yarn run test:jest --coverage

--- a/src/plugins/custom_import_map/package.json
+++ b/src/plugins/custom_import_map/package.json
@@ -12,7 +12,7 @@
     "lint": "yarn run lint:es && yarn run lint:style",
     "lint:es": "node ../../scripts/eslint",
     "lint:style": "node ../../scripts/stylelint",
-    "test:jest": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",
+    "test:jest": "../../node_modules/.bin/jest --config ./test/jest.config.js",
     "postbuild": "echo Renaming build artifact to [$npm_package_config_id-$npm_package_version.zip] && mv build/$npm_package_config_id*.zip build/$npm_package_config_id-$npm_package_version.zip",
     "opensearch": "node ../../scripts/opensearch"
   },

--- a/src/plugins/custom_import_map/test/jest.config.js
+++ b/src/plugins/custom_import_map/test/jest.config.js
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
+process.env.TZ = 'UTC';
 module.exports = {
   rootDir: '../',
   setupFiles: [


### PR DESCRIPTION
Add window and mac platform to run unit test

Signed-off-by: Heemin Kim <heemin@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
