### PR TITLE
Add reorder handle inside layer panel

### DIFF
--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.scss
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.scss
@@ -1,6 +1,6 @@
 .layerControlPanel--show {
   pointer-events: auto;
-  width: $euiSizeL * 10;
+  width: $euiSizeL * 11;
 
   .layerControlPanel__title {
     padding: $euiSizeM $euiSizeM


### PR DESCRIPTION
### Description
Added icon to trigger re-order layer inside panel. Increased panel width to accommodate new icon.

Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>


### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
