### PR TITLE
Add validation for layer basic settings

### DIFF
--- a/maps_dashboards/common/index.ts
+++ b/maps_dashboards/common/index.ts
@@ -19,8 +19,9 @@ export const MAP_LAYER_DEFAULT_OPACITY_STEP = 1;
 export const MAP_LAYER_DEFAULT_BORDER_THICKNESS = 1;
 export const DOCUMENTS_DEFAULT_REQUEST_NUMBER = 20;
 export const DOCUMENTS_DEFAULT_MARKER_SIZE = 5;
-export const LAYER_PANEL_SHOW_LAYER_ICON = 'eye'
-export const LAYER_PANEL_HIDE_LAYER_ICON = 'eyeClosed'
+export const LAYER_PANEL_SHOW_LAYER_ICON = 'eye';
+export const LAYER_PANEL_HIDE_LAYER_ICON = 'eyeClosed';
+export const MAX_LAYER_NAME_LIMIT = 35;
 
 // Starting position [lng, lat] and zoom
 export const MAP_INITIAL_STATE = {

--- a/maps_dashboards/public/components/layer_config/layer_basic_settings.tsx
+++ b/maps_dashboards/public/components/layer_config/layer_basic_settings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiDualRange,
   EuiFieldText,
@@ -23,6 +23,7 @@ import {
   MAP_LAYER_DEFAULT_MIN_OPACITY,
   MAP_LAYER_DEFAULT_MAX_OPACITY,
   MAP_LAYER_DEFAULT_OPACITY_STEP,
+  MAX_LAYER_NAME_LIMIT,
 } from '../../../common';
 import { layersTypeNameMap } from '../../model/layersFunctions';
 
@@ -40,8 +41,27 @@ export const LayerBasicSettings = ({ selectedLayerConfig, setSelectedLayerConfig
     setSelectedLayerConfig({ ...selectedLayerConfig, opacity: Number(e.target.value) });
   };
 
+  const [invalid, setInvalid] = useState<boolean>(selectedLayerConfig.name.length === 0);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const validateName = (name: string) => {
+    if (name?.length === 0) {
+      setInvalid(true);
+      setErrors(['Name cannot be empty']);
+      return;
+    }
+    if (MAX_LAYER_NAME_LIMIT < name?.length) {
+      setInvalid(true);
+      setErrors(['Name should be less than ' + MAX_LAYER_NAME_LIMIT + ' characters']);
+      return;
+    }
+    setInvalid(false);
+  };
+
   const onNameChange = (e: any) => {
-    setSelectedLayerConfig({ ...selectedLayerConfig, name: String(e.target.value) });
+    const layerName = String(e.target.value);
+    setSelectedLayerConfig({ ...selectedLayerConfig, name: layerName });
+    validateName(layerName);
   };
 
   const onDescriptionChange = (e: any) => {
@@ -62,8 +82,13 @@ export const LayerBasicSettings = ({ selectedLayerConfig, setSelectedLayerConfig
             readOnly={true}
           />
         </EuiFormRow>
-        <EuiFormRow label="Name">
-          <EuiFieldText name="layerName" value={selectedLayerConfig.name} onChange={onNameChange} />
+        <EuiFormRow label="Name" error={errors} isInvalid={invalid}>
+          <EuiFieldText
+            name="layerName"
+            value={selectedLayerConfig.name}
+            onChange={onNameChange}
+            isInvalid={invalid}
+          />
         </EuiFormRow>
 
         <EuiFormRow label="Description">


### PR DESCRIPTION
### Description
1. Name cannot be empty.
2. Name cannot be more than 35 characers length.

This will only trigger UI error. The user will still be able to save with error. Disable save if error exists will be added in later PR.

Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
