### PR TITLE
Fetch tooltip fields from cluster

### DIFF
--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
@@ -79,12 +79,16 @@ const LayerControlPanel = memo(({ maplibreRef, setLayers, layers }: Props) => {
         const sourceConfig = layer.source;
         const indexPatternRefName = sourceConfig?.indexPatternRefName;
         const geoField = sourceConfig.geoFieldName;
+        const sourceFields: string[] = [geoField];
+        if (sourceConfig.showTooltips === true && sourceConfig.tooltipFields.length > 0) {
+          sourceFields.push(...sourceConfig.tooltipFields);
+        }
         const request = {
           params: {
             index: indexPatternRefName,
             size: layer.source.documentRequestNumber,
             body: {
-              _source: geoField,
+              _source: sourceFields,
             },
           },
         };

--- a/maps_dashboards/public/model/documentLayerFunctions.ts
+++ b/maps_dashboards/public/model/documentLayerFunctions.ts
@@ -36,11 +36,11 @@ const layerExistInMbSource = (layerConfigId: string, maplibreRef: MaplibreRef) =
   return false;
 };
 
-const getLocationValue = (data: any, geoField: string) => {
-  if (!geoField) {
+const getFieldValue = (data: any, name: string) => {
+  if (!name) {
     return null;
   }
-  const keys = geoField.split('.');
+  const keys = name.split('.');
   return keys.reduce((pre, cur) => {
     return pre?.[cur];
   }, data);
@@ -63,13 +63,13 @@ const getLayerSource = (data: any, layerConfig: DocumentLayerSpecification) => {
   const geoFieldType = getGeoFieldType(layerConfig);
   const featureList: any = [];
   data.forEach((item: any) => {
-    const location = getLocationValue(item._source, geoFieldName);
+    const geoFieldValue = getFieldValue(item._source, geoFieldName);
     let feature;
     if (geoFieldType === 'geo_point') {
       feature = {
         geometry: {
           type: 'Point',
-          coordinates: [location.lon, location.lat],
+          coordinates: [geoFieldValue.lon, geoFieldValue.lat],
         },
         properties: {
           title: item._id,
@@ -79,8 +79,8 @@ const getLayerSource = (data: any, layerConfig: DocumentLayerSpecification) => {
     } else {
       feature = {
         geometry: {
-          type: openSearchGeoJSONMap.get(location.type),
-          coordinates: location.coordinates,
+          type: openSearchGeoJSONMap.get(geoFieldValue.type),
+          coordinates: geoFieldValue.coordinates,
         },
         properties: {
           title: item._id,


### PR DESCRIPTION
### Description
Include tooltip fields to source
- Fetch tooltip fields from cluster, if show tooltip
is enabled and tooltips are added.
- Move tooltip fields to properties

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
