### PR TITLE
Reverse layer list on layer panel

### DIFF
--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
@@ -187,6 +187,11 @@ const LayerControlPanel = memo(({ maplibreRef, setLayers, layers }: Props) => {
     }
   };
 
+  const getReverseLayers = () => {
+    const layersClone = [...layers];
+    return layersClone.reverse();
+  };
+
   if (isLayerControlVisible) {
     return (
       <I18nProvider>
@@ -217,7 +222,7 @@ const LayerControlPanel = memo(({ maplibreRef, setLayers, layers }: Props) => {
             <EuiHorizontalRule margin="none" />
             <EuiDragDropContext onDragEnd={onDragEnd}>
               <EuiDroppable droppableId="LAYERS_HANDLE_DROPPABLE_AREA" spacing="none">
-                {layers.map((layer, index) => {
+                {getReverseLayers().map((layer, index) => {
                   const isLayerSelected =
                     isLayerConfigVisible &&
                     selectedLayerConfig &&


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Reverse layers order on layer control panel, so that the layers order on panel can be consistent with layers order in map. 


<img width="580" alt="image" src="https://user-images.githubusercontent.com/90288540/208540353-fd85b163-3885-4af7-875a-a7abe140b672.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
