### PR TITLE
Move layer if layer order is changed

### DIFF
--- a/maps_dashboards/public/model/layersFunctions.ts
+++ b/maps_dashboards/public/model/layersFunctions.ts
@@ -3,9 +3,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Map as Maplibre } from 'maplibre-gl';
 import { DASHBOARDS_MAPS_LAYER_NAME, DASHBOARDS_MAPS_LAYER_TYPE } from '../../common';
 import { OSMLayerFunctions } from './OSMLayerFunctions';
 import { DocumentLayerFunctions } from './documentLayerFunctions';
+
+interface MaplibreRef {
+  current: Maplibre | null;
+}
+
+const getAllMaplibreLayersIncludesId = (maplibreRef: MaplibreRef, layerId?: string) => {
+  if (!layerId && !maplibreRef) {
+    return [];
+  }
+  return (
+    maplibreRef.current
+      ?.getStyle()
+      .layers.filter((layer) => layer.id?.includes(String(layerId)) === true) || []
+  );
+};
+
+export const LayerActions = {
+  move: (maplibreRef: MaplibreRef, sourceId: string, beforeId?: string) => {
+    const sourceMaplibreLayers = getAllMaplibreLayersIncludesId(maplibreRef, sourceId);
+    if (!sourceMaplibreLayers) {
+      return;
+    }
+    const beforeMaplibreLayers = getAllMaplibreLayersIncludesId(maplibreRef, beforeId);
+    if (!beforeMaplibreLayers || beforeMaplibreLayers.length < 1) {
+      // move to top
+      sourceMaplibreLayers.forEach((layer) => maplibreRef.current?.moveLayer(layer.id));
+      return;
+    }
+    const topOfBeforeLayer = beforeMaplibreLayers[0];
+    sourceMaplibreLayers.forEach((layer) =>
+      maplibreRef.current?.moveLayer(layer.id, topOfBeforeLayer.id)
+    );
+    return;
+  },
+};
 
 export const layersFunctionMap: { [key: string]: any } = {
   [DASHBOARDS_MAPS_LAYER_TYPE.OPENSEARCH_MAP]: OSMLayerFunctions,


### PR DESCRIPTION
### Description
if layer is moved below, the drag drop destination provides where layer should be added before.
if layer is moved above, the drag drop destination provides where layer should be added above. Hence, move to next layer to find before layer index.

Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>


Demo:

https://user-images.githubusercontent.com/11067894/209039792-f878053a-0905-4d19-a369-c260d141e4ff.mov





### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
