### PR TITLE
feat: added multi-layer support to map popup

### DIFF
--- a/maps_dashboards/public/components/map_container/map_container.tsx
+++ b/maps_dashboards/public/components/map_container/map_container.tsx
@@ -5,13 +5,25 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { EuiPanel } from '@elastic/eui';
-import { Map as Maplibre, NavigationControl } from 'maplibre-gl';
+import {
+  Map as Maplibre,
+  MapLayerMouseEvent,
+  MapMouseEvent,
+  NavigationControl,
+  Popup,
+} from 'maplibre-gl';
 import { LayerControlPanel } from '../layer_control_panel';
 import './map_container.scss';
 import { MAP_INITIAL_STATE, MAP_GLYPHS } from '../../../common';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import { IndexPattern } from '../../../../../src/plugins/data/public';
 import { MapState } from '../../model/mapState';
+import {
+  createPopup,
+  getPopupLngLat,
+  groupFeaturesByLayers,
+  isTooltipEnabledLayer,
+} from '../tooltip/create_tooltip';
 
 interface MapContainerProps {
   setLayers: (layers: MapLayerSpecification[]) => void;
@@ -59,6 +71,73 @@ export const MapContainer = ({
       return setZoom(Number(maplibreInstance.getZoom().toFixed(2)));
     });
   }, []);
+
+  useEffect(() => {
+    let clickPopup: Popup | null = null;
+
+    // We don't want to show layer information in the popup for the map tile layer
+    const tooltipEnabledLayers = layers.filter(isTooltipEnabledLayer);
+
+    function onClickMap(e: MapMouseEvent) {
+      // remove previous popup
+      clickPopup?.remove();
+
+      const features = maplibreRef.current?.queryRenderedFeatures(e.point);
+      if (features && maplibreRef.current) {
+        const featureGroup = groupFeaturesByLayers(features, tooltipEnabledLayers);
+        clickPopup = createPopup({ featureGroup });
+        clickPopup
+          ?.setLngLat(getPopupLngLat(features[0].geometry) ?? e.lngLat)
+          .addTo(maplibreRef.current);
+      }
+    }
+
+    let hoverPopup: Popup | null = null;
+
+    function onMouseEnter(e: MapLayerMouseEvent) {
+      hoverPopup?.remove();
+
+      if (maplibreRef.current) {
+        maplibreRef.current.getCanvas().style.cursor = 'pointer';
+        if (e.features) {
+          hoverPopup = createPopup({
+            featureGroup: [e.features],
+            showCloseButton: false,
+            showPagination: false,
+            showLayerSelection: false,
+          });
+          hoverPopup
+            ?.setLngLat(getPopupLngLat(e.features[0].geometry) ?? e.lngLat)
+            .addTo(maplibreRef.current);
+        }
+      }
+    }
+
+    function onMouseLeave(e: MapLayerMouseEvent) {
+      hoverPopup?.remove();
+      if (maplibreRef.current) {
+        maplibreRef.current.getCanvas().style.cursor = '';
+      }
+    }
+
+    if (maplibreRef.current) {
+      maplibreRef.current.on('click', onClickMap);
+      tooltipEnabledLayers.forEach((l) => {
+        maplibreRef.current?.on('mouseenter', l.id, onMouseEnter);
+        maplibreRef.current?.on('mouseleave', l.id, onMouseLeave);
+      });
+    }
+
+    return () => {
+      if (maplibreRef.current) {
+        maplibreRef.current.off('click', onClickMap);
+        tooltipEnabledLayers.forEach((l) => {
+          maplibreRef.current?.off('mouseenter', l.id, onMouseEnter);
+          maplibreRef.current?.off('mouseleave', l.id, onMouseLeave);
+        });
+      }
+    };
+  }, [layers]);
 
   return (
     <div>

--- a/maps_dashboards/public/components/tooltip/create_tooltip.tsx
+++ b/maps_dashboards/public/components/tooltip/create_tooltip.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Popup, MapGeoJSONFeature } from 'maplibre-gl';
+
+import { MapLayerSpecification, OSMLayerSpecification } from '../../model/mapLayerType';
+import { TooltipContainer } from './tooltipContainer';
+
+type Options = {
+  featureGroup: GeoJSON.Feature[][];
+  showCloseButton?: boolean;
+  showPagination?: boolean;
+  showLayerSelection?: boolean;
+};
+
+export function isTooltipEnabledLayer(
+  layer: MapLayerSpecification
+): layer is Exclude<MapLayerSpecification, OSMLayerSpecification> {
+  return layer.type !== 'opensearch_vector_tile_map' && layer.source.showTooltips === true;
+}
+
+export function groupFeaturesByLayers(
+  features: MapGeoJSONFeature[],
+  layers: Exclude<MapLayerSpecification, OSMLayerSpecification>[]
+) {
+  const featureGroups: MapGeoJSONFeature[][] = [];
+  if (layers.length > 0) {
+    layers.forEach((l) => {
+      const layerFeatures = features.filter((f) => f.layer.source === l.id);
+      if (layerFeatures.length > 0) {
+        featureGroups.push(layerFeatures);
+      }
+    });
+  } else {
+    featureGroups.push(features);
+  }
+  return featureGroups;
+}
+
+export function getPopupLngLat(geometry: GeoJSON.Geometry) {
+  // geometry.coordinates is different for different geometry.type, here we use the geometry.coordinates
+  // of a Point as the position of the popup. For other types, such as Polygon, MultiPolygon, etc,
+  // use mouse position should be better
+  if (geometry.type === 'Point') {
+    return [geometry.coordinates[0], geometry.coordinates[1]] as [number, number];
+  } else {
+    return null;
+  }
+}
+
+export function createPopup({
+  featureGroup,
+  showCloseButton = true,
+  showPagination = true,
+  showLayerSelection = true,
+}: Options) {
+  const popup = new Popup({
+    closeButton: false,
+    closeOnClick: false,
+    maxWidth: 'max-content',
+  });
+
+  // Don't show popup if no feature
+  if (featureGroup.length === 0) {
+    return null;
+  }
+
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <TooltipContainer
+      featureGroup={featureGroup}
+      onClose={popup.remove}
+      showCloseButton={showCloseButton}
+      showPagination={showPagination}
+      showLayerSelection={showLayerSelection}
+    />,
+    div
+  );
+
+  return popup.setDOMContent(div);
+}

--- a/maps_dashboards/public/components/tooltip/tooltipHeaderContent.tsx
+++ b/maps_dashboards/public/components/tooltip/tooltipHeaderContent.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 interface Props {
   title: string;
-  isClickEvent: boolean;
+  showCloseButton: boolean;
   onClose: Function;
 }
 
@@ -23,7 +23,7 @@ const TooltipHeaderContent = (props: Props) => {
           </h4>
         </EuiTextColor>
       </EuiFlexItem>
-      {props.isClickEvent && (
+      {props.showCloseButton && (
         <EuiFlexItem key="closeButton" grow={false}>
           <EuiButtonIcon
             onClick={() => {

--- a/maps_dashboards/public/components/tooltip/tooltipTable.tsx
+++ b/maps_dashboards/public/components/tooltip/tooltipTable.tsx
@@ -3,16 +3,49 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBasicTable, EuiFlexGroup, EuiFlexItem, EuiPagination, EuiText } from '@elastic/eui';
-import React, { useState, Fragment } from 'react';
+import {
+  EuiBasicTable,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPagination,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import React, { useState, Fragment, useCallback } from 'react';
+
+export type RowData = {
+  key: string;
+  value: string;
+};
+export type PageData = RowData[];
+export type TableData = PageData[];
+
+export const ALL_LAYERS = -1;
 
 interface Props {
-  pages: any[];
-  isClickEvent: boolean;
+  tables: TableData[];
+  onLayerChange?: (layer: number) => void;
+  showPagination?: boolean;
+  showLayerSelection?: boolean;
 }
 
-const TooltipTable = (props: Props) => {
-  const [activePage, setActivePage] = useState(0);
+function getLayerLabel(layerIndex: number) {
+  if (layerIndex >= 0) {
+    return `layer-${layerIndex + 1}`;
+  }
+  return 'All layers';
+}
+
+const TooltipTable = ({
+  tables,
+  onLayerChange,
+  showPagination = true,
+  showLayerSelection = true,
+}: Props) => {
+  const [selectedLayer, setSelectedLayer] = useState(0);
+  const [activePages, setActivePages] = useState<Record<number, number | undefined>>({});
   const columns = [
     {
       field: 'key',
@@ -36,6 +69,37 @@ const TooltipTable = (props: Props) => {
     };
   };
 
+  const handleLayerChange = useCallback((data: EuiComboBoxOptionOption<number>[]) => {
+    if (data.length > 0) {
+      const layer = data[0]?.value ?? 0;
+      setSelectedLayer(layer);
+      if (onLayerChange) {
+        onLayerChange(layer);
+      }
+    }
+  }, []);
+
+  const onSelectPage = useCallback(
+    (pageIndex) => {
+      setActivePages((state) => {
+        const newState = { ...state };
+        newState[selectedLayer] = pageIndex;
+        return newState;
+      });
+    },
+    [selectedLayer]
+  );
+
+  const options = [{ label: 'All layers', value: ALL_LAYERS }];
+  tables.forEach((_, i) => {
+    options.push({ label: `layer-${i + 1}`, value: i });
+  });
+
+  const selectedOptions = [{ label: getLayerLabel(selectedLayer), value: selectedLayer }];
+  const activePage = activePages[selectedLayer] ?? 0;
+  const tableItems = selectedLayer >= 0 ? tables[selectedLayer] : tables.flat();
+  const pageItems = tableItems[activePage];
+
   const getCellProps = (item, column) => {
     const { id } = item;
     const { field } = column;
@@ -45,33 +109,14 @@ const TooltipTable = (props: Props) => {
       textOnly: true,
     };
   };
-  const buildMessage = (count: number) => {
-    return (
-      <EuiText textAlign="center" size="xs">
-        {1} of {count}
-      </EuiText>
-    );
-  };
-
-  const buildPagination = (count: number) => {
-    return (
-      <EuiPagination
-        aria-label="Compressed pagination"
-        pageCount={count}
-        activePage={activePage}
-        onPageClick={(pageIndex) => setActivePage(pageIndex)}
-        compressed
-      />
-    );
-  };
 
   return (
     <Fragment>
       <EuiFlexGroup responsive={false}>
-        <EuiFlexItem grow={false}>
+        <EuiFlexItem style={{ overflow: 'scroll', maxHeight: 300 }}>
           <EuiBasicTable
             isSelectable={false}
-            items={props.pages[activePage]}
+            items={pageItems}
             columns={columns}
             tableLayout={'auto'}
             rowProps={getRowProps}
@@ -79,11 +124,33 @@ const TooltipTable = (props: Props) => {
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiFlexGroup justifyContent="spaceAround">
+      <EuiSpacer size="s" />
+      <EuiFlexGroup justifyContent="spaceAround" alignItems="center">
+        {showLayerSelection && (
+          <EuiFlexItem>
+            <EuiComboBox
+              placeholder="Select a layer"
+              singleSelection={{ asPlainText: true }}
+              selectedOptions={selectedOptions}
+              options={options}
+              onChange={handleLayerChange}
+            />
+          </EuiFlexItem>
+        )}
         <EuiFlexItem grow={false}>
-          {props.isClickEvent
-            ? buildPagination(props.pages.length)
-            : buildMessage(props.pages.length)}
+          {showPagination ? (
+            <EuiPagination
+              aria-label="Compressed pagination"
+              pageCount={tableItems.length}
+              activePage={activePage}
+              onPageClick={onSelectPage}
+              compressed
+            />
+          ) : (
+            <EuiText textAlign="center" size="xs">
+              {1} of {tableItems.length}
+            </EuiText>
+          )}
         </EuiFlexItem>
       </EuiFlexGroup>
     </Fragment>

--- a/maps_dashboards/public/model/DataLayerController.ts
+++ b/maps_dashboards/public/model/DataLayerController.ts
@@ -63,7 +63,7 @@ export const doDataLayerRender = async (
         if (isCompleteResponse(response)) {
           const dataSource = response.rawResponse.hits.hits;
           layersFunctionMap[layer.type].render(maplibreRef, layer, dataSource);
-          layersFunctionMap[layer.type].addTooltip(maplibreRef, layer);
+          // layersFunctionMap[layer.type].addTooltip(maplibreRef, layer);
           search$.unsubscribe();
         } else {
           notifications.toasts.addWarning('An error has occurred when query dataSource');


### PR DESCRIPTION
Refactor map popup rendering logic, 
1. Abstract a reusable popup rendering logic.
2. For click-popups which need to display multi-layers information, added an event listener globally and then query features from all layers at the current position.
3. For hover-popups which show information of the current layer features, moved the popup rendering logic out from the layer render logic(in the layer control panel component).

Signed-off-by: Yulong Ruan <ruanyl@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
