### PR TITLE
feat: query with geo bounding box

### DIFF
--- a/maps_dashboards/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/maps_dashboards/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -193,12 +193,21 @@ export const DocumentLayerSource = ({
     setSelectedLayerConfig({ ...selectedLayerConfig, source });
   };
 
+  const onToggleGeoBoundingBox = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const source = { ...selectedLayerConfig.source, useGeoBoundingBoxFilter: e.target.checked };
+    setSelectedLayerConfig({ ...selectedLayerConfig, source });
+  };
+
   const shouldTooltipSectionOpen = () => {
     return (
       selectedLayerConfig.source.showTooltips &&
       selectedLayerConfig.source.tooltipFields?.length > 0
     );
   };
+
+  const filterPanelInitialIsOpen =
+    selectedLayerConfig.source.filters?.length > 0 ||
+    selectedLayerConfig.source.useGeoBoundingBoxFilter;
 
   return (
     <div>
@@ -281,7 +290,7 @@ export const DocumentLayerSource = ({
           title="Filters"
           titleSize="xxs"
           isCollapsible={true}
-          initialIsOpen={selectedLayerConfig.source.filters?.length > 0}
+          initialIsOpen={filterPanelInitialIsOpen}
         >
           <SearchBar
             appName="maps-dashboards"
@@ -290,6 +299,17 @@ export const DocumentLayerSource = ({
             filters={selectedLayerConfig.source.filters ?? []}
             onFiltersUpdated={onFiltersUpdated}
           />
+          <EuiSpacer />
+          <EuiFormRow>
+            <EuiCheckbox
+              id={`${selectedLayerConfig.id}-bounding-box-filter`}
+              disabled={selectedLayerConfig.source.geoFieldType !== 'geo_point'}
+              label={'Only request data around map extent'}
+              checked={selectedLayerConfig.source.useGeoBoundingBoxFilter ? true : false}
+              onChange={onToggleGeoBoundingBox}
+              compressed
+            />
+          </EuiFormRow>
         </EuiCollapsibleNavGroup>
       </EuiPanel>
       <EuiSpacer size="m" />

--- a/maps_dashboards/public/components/map_container/map_container.tsx
+++ b/maps_dashboards/public/components/map_container/map_container.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { EuiPanel } from '@elastic/eui';
-import { LngLat, Map as Maplibre, MapMouseEvent, NavigationControl, Popup } from 'maplibre-gl';
+import { LngLat, Map as Maplibre, NavigationControl, Popup, MapEventType } from 'maplibre-gl';
 import { debounce } from 'lodash';
 import { LayerControlPanel } from '../layer_control_panel';
 import './map_container.scss';
@@ -88,7 +88,7 @@ export const MapContainer = ({
       }
     }
 
-    function onMouseMoveMap(e: MapMouseEvent) {
+    function onMouseMoveMap(e: MapEventType['mousemove']) {
       setCoordinates(e.lngLat.wrap());
 
       // remove previous popup

--- a/maps_dashboards/public/components/map_container/map_container.tsx
+++ b/maps_dashboards/public/components/map_container/map_container.tsx
@@ -6,13 +6,17 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { EuiPanel } from '@elastic/eui';
 import { LngLat, Map as Maplibre, MapMouseEvent, NavigationControl, Popup } from 'maplibre-gl';
+import { debounce } from 'lodash';
 import { LayerControlPanel } from '../layer_control_panel';
 import './map_container.scss';
-import { MAP_INITIAL_STATE, MAP_GLYPHS } from '../../../common';
+import { MAP_INITIAL_STATE, MAP_GLYPHS, DASHBOARDS_MAPS_LAYER_TYPE } from '../../../common';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import { IndexPattern } from '../../../../../src/plugins/data/public';
 import { MapState } from '../../model/mapState';
 import { createPopup, getPopupLngLat, isTooltipEnabledLayer } from '../tooltip/create_tooltip';
+import { handleDataLayerRender } from '../../model/layerRenderController';
+import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { MapServices } from '../../types';
 
 interface MapContainerProps {
   setLayers: (layers: MapLayerSpecification[]) => void;
@@ -31,6 +35,7 @@ export const MapContainer = ({
   maplibreRef,
   mapState,
 }: MapContainerProps) => {
+  const { services } = useOpenSearchDashboards<MapServices>();
   const mapContainer = useRef(null);
   const [mounted, setMounted] = useState(false);
   const [zoom, setZoom] = useState<number>(MAP_INITIAL_STATE.zoom);
@@ -62,6 +67,7 @@ export const MapContainer = ({
     });
   }, []);
 
+  // Create onClick tooltip for each layer features that has tooltip enabled
   useEffect(() => {
     let clickPopup: Popup | null = null;
     let hoverPopup: Popup | null = null;
@@ -69,7 +75,7 @@ export const MapContainer = ({
     // We don't want to show layer information in the popup for the map tile layer
     const tooltipEnabledLayers = layers.filter(isTooltipEnabledLayer);
 
-    function onClickMap(e: MapMouseEvent) {
+    function onClickMap(e: MapEventType['click']) {
       // remove previous popup
       clickPopup?.remove();
 
@@ -125,6 +131,35 @@ export const MapContainer = ({
       }
     };
   }, [layers]);
+
+  // Handle map bounding box change, it should update the search if "request data around map extent" was enabled
+  useEffect(() => {
+    function renderLayers() {
+      layers.forEach((layer: MapLayerSpecification) => {
+        // We don't send search query if the layer doesn't have "request data around map extent" enabled
+        if (
+          layer.type === DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS &&
+          layer.source.useGeoBoundingBoxFilter
+        ) {
+          handleDataLayerRender(layer, mapState, services, maplibreRef, undefined);
+        }
+      });
+    }
+
+    // Rerender layers with 200ms debounce to avoid calling the search API too frequently, especially when
+    // resizing the window, the "moveend" event could be fired constantly
+    const debouncedRenderLayers = debounce(renderLayers, 200);
+
+    if (maplibreRef.current) {
+      maplibreRef.current.on('moveend', debouncedRenderLayers);
+    }
+
+    return () => {
+      if (maplibreRef.current) {
+        maplibreRef.current.off('moveend', debouncedRenderLayers);
+      }
+    };
+  }, [layers, mapState, services]);
 
   return (
     <div>

--- a/maps_dashboards/public/components/tooltip/create_tooltip.tsx
+++ b/maps_dashboards/public/components/tooltip/create_tooltip.tsx
@@ -16,7 +16,11 @@ type Options = {
 export function isTooltipEnabledLayer(
   layer: MapLayerSpecification
 ): layer is DocumentLayerSpecification {
-  return layer.type !== 'opensearch_vector_tile_map' && layer.source.showTooltips === true;
+  return (
+    layer.type !== 'opensearch_vector_tile_map' &&
+    layer.type !== 'custom_map' &&
+    layer.source.showTooltips === true
+  );
 }
 
 export function groupFeaturesByLayers(

--- a/maps_dashboards/public/model/documentLayerFunctions.ts
+++ b/maps_dashboards/public/model/documentLayerFunctions.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Map as Maplibre, Popup, MapGeoJSONFeature } from 'maplibre-gl';
-import { createPopup, getPopupLngLat } from '../components/tooltip/create_tooltip';
+import { Map as Maplibre } from 'maplibre-gl';
 import { DocumentLayerSpecification } from './mapLayerType';
 import { convertGeoPointToGeoJSON, isGeoJSON } from '../utils/geo_formater';
 import { getMaplibreBeforeLayerId, layerExistInMbSource } from './layersFunctions';

--- a/maps_dashboards/public/model/mapLayerType.ts
+++ b/maps_dashboards/public/model/mapLayerType.ts
@@ -43,6 +43,7 @@ export type DocumentLayerSpecification = {
     documentRequestNumber: number;
     showTooltips: boolean;
     tooltipFields: string[];
+    useGeoBoundingBoxFilter: boolean;
     filters: Filter[];
   };
   style: {


### PR DESCRIPTION
### What's changed:
1. When the map application is opened(initial load), it will query data with the current map bounds
2. When user zoom in/out, move the map, resize the window, etc. New queries will be fired with the updated bounding box and then update the map accordingly.

### Bug fixes:
- fixed wrong maplibre instance passed to addTooltip() function which results in a runtime error
- fixed empty onHover popup rendered on layer which has tooltip disabled

Signed-off-by: Yulong Ruan <ruanyl@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
