### PR TITLE
Update property when switching layer config panel

### DIFF
--- a/maps_dashboards/public/components/layer_config/documents_config/document_layer_config_panel.tsx
+++ b/maps_dashboards/public/components/layer_config/documents_config/document_layer_config_panel.tsx
@@ -5,7 +5,6 @@
 
 import React, { Fragment } from 'react';
 import { EuiSpacer, EuiTabbedContent } from '@elastic/eui';
-import { IndexPattern } from '../../../../../../src/plugins/data/public';
 import { DocumentLayerSpecification } from '../../../model/mapLayerType';
 import { LayerBasicSettings } from '../layer_basic_settings';
 import { DocumentLayerSource } from './document_layer_source';
@@ -15,7 +14,6 @@ interface Props {
   selectedLayerConfig: DocumentLayerSpecification;
   setSelectedLayerConfig: Function;
   setIsUpdateDisabled: Function;
-  layersIndexPatterns: IndexPattern[];
   isLayerExists: Function;
 }
 

--- a/maps_dashboards/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/maps_dashboards/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -49,15 +49,9 @@ export const DocumentLayerSource = ({
   const [indexPattern, setIndexPattern] = useState<IndexPattern | null>();
   const [geoFields, setGeoFields] = useState<IndexPatternField[]>();
   const [selectedField, setSelectedField] = useState<IndexPatternField | null | undefined>();
-  const [documentRequestNumber, setDocumentRequestNumber] = useState<number>(
-    selectedLayerConfig.source.documentRequestNumber
-  );
   const [hasInvalidRequestNumber, setHasInvalidRequestNumber] = useState<boolean>(false);
   const [showTooltips, setShowTooltips] = useState<boolean>(
     selectedLayerConfig.source.showTooltips
-  );
-  const [selectedTooltipFields, setSelectedTooltipFields] = useState<string[]>(
-    selectedLayerConfig.source.tooltipFields
   );
 
   const errorsMap = {
@@ -66,30 +60,14 @@ export const DocumentLayerSource = ({
   };
 
   useEffect(() => {
-    const disableUpdate =
-      !indexPattern || !selectedField || documentRequestNumber < 1 || documentRequestNumber > 10000;
+    const disableUpdate = !indexPattern || !selectedField || hasInvalidRequestNumber;
     setIsUpdateDisabled(disableUpdate);
-  }, [setIsUpdateDisabled, indexPattern, selectedField, documentRequestNumber]);
+  }, [setIsUpdateDisabled, indexPattern, selectedField, hasInvalidRequestNumber]);
 
   const formatFieldToComboBox = (field?: IndexPatternField | null) => {
     if (!field) return [];
     return formatFieldsToComboBox([field]);
   };
-
-  useEffect(() => {
-    if (selectedLayerConfig.source.documentRequestNumber !== documentRequestNumber) {
-      setDocumentRequestNumber(selectedLayerConfig.source.documentRequestNumber);
-    }
-    if (selectedLayerConfig.source.showTooltips !== showTooltips) {
-      setShowTooltips(selectedLayerConfig.source.showTooltips);
-    }
-    shouldTooltipSectionOpen();
-  }, [
-    documentRequestNumber,
-    selectedLayerConfig.source.documentRequestNumber,
-    selectedLayerConfig.source.showTooltips,
-    showTooltips,
-  ]);
 
   const formatFieldsToComboBox = (fields?: IndexPatternField[]) => {
     if (!fields) return [];
@@ -137,8 +115,7 @@ export const DocumentLayerSource = ({
 
   const onDocumentRequestNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    const selectedNumber = parseInt(value, 10) || 1;
-    setDocumentRequestNumber(selectedNumber);
+    const selectedNumber = parseInt(value, 10);
     const source = { ...selectedLayerConfig.source, documentRequestNumber: selectedNumber };
     setSelectedLayerConfig({ ...selectedLayerConfig, source });
   };
@@ -148,7 +125,6 @@ export const DocumentLayerSource = ({
     for (const option of options) {
       tooltipSelection.push(option.label);
     }
-    setSelectedTooltipFields(tooltipSelection);
     const source = { ...selectedLayerConfig.source, tooltipFields: tooltipSelection };
     setSelectedLayerConfig({ ...selectedLayerConfig, source });
   };
@@ -187,11 +163,6 @@ export const DocumentLayerSource = ({
       (field) => field.name === selectedLayerConfig.source.geoFieldName
     );
     setSelectedField(savedField);
-    if (selectedLayerConfig.source.indexPatternId === indexPattern?.id) {
-      setSelectedTooltipFields(selectedLayerConfig.source.tooltipFields);
-    } else {
-      setSelectedTooltipFields([]);
-    }
   }, [indexPattern]);
 
   useEffect(() => {
@@ -210,8 +181,11 @@ export const DocumentLayerSource = ({
   }, [selectedField]);
 
   useEffect(() => {
-    setHasInvalidRequestNumber(documentRequestNumber < 1 || documentRequestNumber > 10000);
-  }, [documentRequestNumber]);
+    setHasInvalidRequestNumber(
+      selectedLayerConfig.source.documentRequestNumber < 1 ||
+        selectedLayerConfig.source.documentRequestNumber > 10000
+    );
+  }, [selectedLayerConfig.source.documentRequestNumber]);
 
   const onShowTooltipsChange = (event: { target: { checked: React.SetStateAction<boolean> } }) => {
     setShowTooltips(event.target.checked);
@@ -283,7 +257,7 @@ export const DocumentLayerSource = ({
                 <EuiSpacer size="xs" />
                 <EuiFieldNumber
                   placeholder="Number of documents"
-                  value={documentRequestNumber}
+                  value={selectedLayerConfig.source.documentRequestNumber}
                   onChange={onDocumentRequestNumberChange}
                   aria-label="Use aria labels when no actual label is in use"
                   isInvalid={hasInvalidRequestNumber}
@@ -340,7 +314,9 @@ export const DocumentLayerSource = ({
               <EuiSpacer size="xs" />
               <EuiComboBox
                 options={tooltipFieldsOptions()}
-                selectedOptions={formatTooltipFieldsToComboBox(selectedTooltipFields)}
+                selectedOptions={formatTooltipFieldsToComboBox(
+                  selectedLayerConfig.source.tooltipFields
+                )}
                 singleSelection={false}
                 onChange={onTooltipSelectionChange}
                 sortMatchesBy="startsWith"

--- a/maps_dashboards/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/maps_dashboards/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -30,14 +30,12 @@ interface Props {
   setSelectedLayerConfig: Function;
   selectedLayerConfig: DocumentLayerSpecification;
   setIsUpdateDisabled: Function;
-  layersIndexPatterns: IndexPattern[];
 }
 
 export const DocumentLayerSource = ({
   setSelectedLayerConfig,
   selectedLayerConfig,
   setIsUpdateDisabled,
-  layersIndexPatterns,
 }: Props) => {
   const {
     services: {
@@ -77,6 +75,21 @@ export const DocumentLayerSource = ({
     if (!field) return [];
     return formatFieldsToComboBox([field]);
   };
+
+  useEffect(() => {
+    if (selectedLayerConfig.source.documentRequestNumber !== documentRequestNumber) {
+      setDocumentRequestNumber(selectedLayerConfig.source.documentRequestNumber);
+    }
+    if (selectedLayerConfig.source.showTooltips !== showTooltips) {
+      setShowTooltips(selectedLayerConfig.source.showTooltips);
+    }
+    shouldTooltipSectionOpen();
+  }, [
+    documentRequestNumber,
+    selectedLayerConfig.source.documentRequestNumber,
+    selectedLayerConfig.source.showTooltips,
+    showTooltips,
+  ]);
 
   const formatFieldsToComboBox = (fields?: IndexPatternField[]) => {
     if (!fields) return [];
@@ -153,14 +166,14 @@ export const DocumentLayerSource = ({
   useEffect(() => {
     const selectIndexPattern = async () => {
       if (selectedLayerConfig.source.indexPatternId) {
-        const selectedIndexPattern = layersIndexPatterns.find(
-          (ip) => ip.id === selectedLayerConfig.source.indexPatternId
+        const selectedIndexPattern = await indexPatterns.get(
+          selectedLayerConfig.source.indexPatternId
         );
         setIndexPattern(selectedIndexPattern);
       }
     };
     selectIndexPattern();
-  }, [indexPatterns]);
+  }, [indexPatterns, selectedLayerConfig.source.indexPatternId]);
 
   // Update the fields list every time the index pattern is modified.
   useEffect(() => {

--- a/maps_dashboards/public/components/layer_config/documents_config/document_layer_style.tsx
+++ b/maps_dashboards/public/components/layer_config/documents_config/document_layer_style.tsx
@@ -27,20 +27,19 @@ interface Props {
 }
 
 export const DocumentLayerStyle = ({ setSelectedLayerConfig, selectedLayerConfig }: Props) => {
-  const [fillColor, setFillColor] = useColorPickerState(selectedLayerConfig?.style?.fillColor);
-  const [borderColor, setBorderColor] = useColorPickerState(
-    selectedLayerConfig?.style?.borderColor
-  );
-  const [borderThickness, setBorderThickness] = useState<number>(
-    selectedLayerConfig?.style?.borderThickness
-  );
-  const [markerSize, setMarkerSize] = useState<number>(selectedLayerConfig?.style?.markerSize);
+  const [fillColor, setFillColor] = useState(selectedLayerConfig?.style?.fillColor);
+  const [borderColor, setBorderColor] = useState(selectedLayerConfig?.style?.borderColor);
   const [hasInvalidThickness, setHasInvalidThickness] = useState<boolean>(false);
   const [hasInvalidSize, setHasInvalidSize] = useState<boolean>(false);
   const geoTypeToggleButtonGroupPrefix = 'geoTypeToggleButtonGroup';
   const [toggleGeoTypeIdSelected, setToggleGeoTypeIdSelected] = useState(
     `${geoTypeToggleButtonGroupPrefix}__Point`
   );
+
+  useEffect(() => {
+    setFillColor(selectedLayerConfig?.style?.fillColor);
+    setBorderColor(selectedLayerConfig?.style?.borderColor);
+  }, [selectedLayerConfig]);
 
   useEffect(() => {
     setSelectedLayerConfig({
@@ -70,7 +69,6 @@ export const DocumentLayerStyle = ({ setSelectedLayerConfig, selectedLayerConfig
         borderThickness: Number(e.target.value),
       },
     });
-    setBorderThickness(Number(e.target.value));
   };
 
   const onMarkerSizeChange = (e: any) => {
@@ -81,24 +79,29 @@ export const DocumentLayerStyle = ({ setSelectedLayerConfig, selectedLayerConfig
         markerSize: Number(e.target.value),
       },
     });
-    setMarkerSize(Number(e.target.value));
   };
 
   useEffect(() => {
-    if (borderThickness < 0 || borderThickness > 100) {
+    if (
+      selectedLayerConfig?.style?.borderThickness < 0 ||
+      selectedLayerConfig?.style?.borderThickness > 100
+    ) {
       setHasInvalidThickness(true);
     } else {
       setHasInvalidThickness(false);
     }
-  }, [borderThickness]);
+  }, [selectedLayerConfig?.style?.borderThickness]);
 
   useEffect(() => {
-    if (markerSize < 0 || markerSize > 100) {
+    if (
+      selectedLayerConfig?.style?.markerSize < 0 ||
+      selectedLayerConfig?.style?.markerSize > 100
+    ) {
       setHasInvalidSize(true);
     } else {
       setHasInvalidSize(false);
     }
-  }, [markerSize]);
+  }, [selectedLayerConfig?.style?.markerSize]);
 
   const toggleButtonsGeoType = [
     {
@@ -193,13 +196,13 @@ export const DocumentLayerStyle = ({ setSelectedLayerConfig, selectedLayerConfig
             <ColorPicker color={borderColor} setColor={setBorderColor} label="Border color" />
             <WidthSelector
               label="Border thickness"
-              size={borderThickness}
+              size={selectedLayerConfig?.style?.borderThickness}
               onWidthChange={onBorderThicknessChange}
               hasInvalid={hasInvalidThickness}
             />
             <WidthSelector
               label="Marker size"
-              size={markerSize}
+              size={selectedLayerConfig?.style?.markerSize}
               onWidthChange={onMarkerSizeChange}
               hasInvalid={hasInvalidSize}
             />
@@ -210,7 +213,7 @@ export const DocumentLayerStyle = ({ setSelectedLayerConfig, selectedLayerConfig
             <ColorPicker color={fillColor} setColor={setFillColor} label="Fill color" />
             <WidthSelector
               label="Border thickness"
-              size={borderThickness}
+              size={selectedLayerConfig?.style?.borderThickness}
               onWidthChange={onBorderThicknessChange}
               hasInvalid={hasInvalidThickness}
             />
@@ -222,7 +225,7 @@ export const DocumentLayerStyle = ({ setSelectedLayerConfig, selectedLayerConfig
             <ColorPicker color={borderColor} setColor={setBorderColor} label="Border color" />
             <WidthSelector
               label="Border thickness"
-              size={borderThickness}
+              size={selectedLayerConfig?.style?.borderThickness}
               onWidthChange={onBorderThicknessChange}
               hasInvalid={hasInvalidThickness}
             />

--- a/maps_dashboards/public/components/layer_config/layer_config_panel.tsx
+++ b/maps_dashboards/public/components/layer_config/layer_config_panel.tsx
@@ -63,7 +63,11 @@ export const LayerConfigPanel = ({
   const [isUpdateDisabled, setIsUpdateDisabled] = useState(false);
 
   useEffect(() => {
-    if (originLayerConfig === null || originLayerConfig.id !== selectedLayerConfig.id) {
+    if (
+      originLayerConfig === null ||
+      originLayerConfig.id !== selectedLayerConfig.id ||
+      !isEqual(originLayerConfig.source, selectedLayerConfig.source)
+    ) {
       setOriginLayerConfig(cloneDeep(selectedLayerConfig));
     }
   }, [originLayerConfig, selectedLayerConfig]);

--- a/maps_dashboards/public/components/layer_config/layer_config_panel.tsx
+++ b/maps_dashboards/public/components/layer_config/layer_config_panel.tsx
@@ -28,7 +28,6 @@ import { BaseMapLayerConfigPanel } from './index';
 import { DASHBOARDS_MAPS_LAYER_TYPE } from '../../../common';
 import { DocumentLayerConfigPanel } from './documents_config/document_layer_config_panel';
 import { layersTypeIconMap } from '../../model/layersFunctions';
-import { IndexPattern } from '../../../../../src/plugins/data/public';
 import { CustomMapConfigPanel } from './custom_map_config/custom_map_config_panel';
 
 interface Props {
@@ -42,8 +41,6 @@ interface Props {
   isLayerExists: Function;
   originLayerConfig: MapLayerSpecification | null;
   setOriginLayerConfig: Function;
-  unsavedModalVisible: boolean;
-  setUnsavedModalVisible: Function;
 }
 
 export const LayerConfigPanel = ({
@@ -57,17 +54,12 @@ export const LayerConfigPanel = ({
   isLayerExists,
   originLayerConfig,
   setOriginLayerConfig,
-  unsavedModalVisible,
-  setUnsavedModalVisible,
 }: Props) => {
   const [isUpdateDisabled, setIsUpdateDisabled] = useState(false);
+  const [unsavedModalVisible, setUnsavedModalVisible] = useState(false);
 
   useEffect(() => {
-    if (
-      originLayerConfig === null ||
-      originLayerConfig.id !== selectedLayerConfig.id ||
-      !isEqual(originLayerConfig.source, selectedLayerConfig.source)
-    ) {
+    if (originLayerConfig === null || originLayerConfig.id !== selectedLayerConfig.id) {
       setOriginLayerConfig(cloneDeep(selectedLayerConfig));
     }
   }, [originLayerConfig, selectedLayerConfig]);
@@ -93,6 +85,7 @@ export const LayerConfigPanel = ({
   const onUpdate = () => {
     updateLayer();
     closeLayerConfigPanel(false);
+    setOriginLayerConfig(null);
     if (isNewLayer) {
       setIsNewLayer(false);
     }

--- a/maps_dashboards/public/components/layer_config/layer_config_panel.tsx
+++ b/maps_dashboards/public/components/layer_config/layer_config_panel.tsx
@@ -39,9 +39,11 @@ interface Props {
   removeLayer: Function;
   isNewLayer: boolean;
   setIsNewLayer: Function;
-  layersIndexPatterns: IndexPattern[];
-  updateIndexPatterns: Function;
   isLayerExists: Function;
+  originLayerConfig: MapLayerSpecification | null;
+  setOriginLayerConfig: Function;
+  unsavedModalVisible: boolean;
+  setUnsavedModalVisible: Function;
 }
 
 export const LayerConfigPanel = ({
@@ -52,27 +54,32 @@ export const LayerConfigPanel = ({
   removeLayer,
   isNewLayer,
   setIsNewLayer,
-  layersIndexPatterns,
-  updateIndexPatterns,
   isLayerExists,
+  originLayerConfig,
+  setOriginLayerConfig,
+  unsavedModalVisible,
+  setUnsavedModalVisible,
 }: Props) => {
   const [isUpdateDisabled, setIsUpdateDisabled] = useState(false);
-  const [originLayerConfig, setOriginLayerConfig] = useState<MapLayerSpecification | null>(null);
-  const [warnModalVisible, setWarnModalVisible] = useState(false);
 
   useEffect(() => {
-    setOriginLayerConfig(cloneDeep(selectedLayerConfig));
-  }, []);
+    if (originLayerConfig === null || originLayerConfig.id !== selectedLayerConfig.id) {
+      setOriginLayerConfig(cloneDeep(selectedLayerConfig));
+    }
+  }, [originLayerConfig, selectedLayerConfig]);
 
   const discardChanges = () => {
     closeLayerConfigPanel(false);
     setSelectedLayerConfig(undefined);
+    setOriginLayerConfig(null);
+    setUnsavedModalVisible(false);
   };
+
   const onClose = () => {
     if (isEqual(originLayerConfig, selectedLayerConfig)) {
       discardChanges();
     } else {
-      setWarnModalVisible(true);
+      setUnsavedModalVisible(true);
     }
     if (isNewLayer) {
       removeLayer(selectedLayerConfig.id);
@@ -88,7 +95,7 @@ export const LayerConfigPanel = ({
   };
 
   const closeModal = () => {
-    setWarnModalVisible(false);
+    setUnsavedModalVisible(false);
   };
 
   return (
@@ -125,7 +132,6 @@ export const LayerConfigPanel = ({
                 selectedLayerConfig={selectedLayerConfig}
                 setSelectedLayerConfig={setSelectedLayerConfig}
                 setIsUpdateDisabled={setIsUpdateDisabled}
-                layersIndexPatterns={layersIndexPatterns}
                 isLayerExists={isLayerExists}
               />
             )}
@@ -154,7 +160,7 @@ export const LayerConfigPanel = ({
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutFooter>
-      {warnModalVisible && (
+      {unsavedModalVisible && (
         <EuiModal onClose={closeModal}>
           <EuiModalHeader>
             <EuiModalHeaderTitle>Unsaved changes</EuiModalHeaderTitle>

--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
@@ -88,6 +88,9 @@ export const LayerControlPanel = memo(
     const [selectedDeleteLayer, setSelectedDeleteLayer] = useState<
       MapLayerSpecification | undefined
     >();
+    const [wantSelectNewLayer, setWantSelectNewLayer] = useState<MapLayerSpecification | null>(
+      null
+    );
 
     useEffect(() => {
       if (!isUpdatingLayerRender && initialLayersLoaded) {
@@ -181,15 +184,26 @@ export const LayerControlPanel = memo(
       if (!selectedLayerConfig || !originLayerConfig) {
         return false;
       }
-      return isEqual(originLayerConfig, selectedLayerConfig);
+      return !isEqual(originLayerConfig, selectedLayerConfig);
     };
 
     const onClickLayerName = (layer: MapLayerSpecification) => {
       if (hasUnsavedChanges()) {
         setUnsavedModalVisible(true);
+        setWantSelectNewLayer(layer);
       } else {
         setSelectedLayerConfig(layer);
         setIsLayerConfigVisible(true);
+        setWantSelectNewLayer(null);
+      }
+    };
+
+    const updateUnsavedModalVisible = (visible: boolean) => {
+      setUnsavedModalVisible(visible);
+      if (!visible && wantSelectNewLayer) {
+        setSelectedLayerConfig(wantSelectNewLayer);
+        setIsLayerConfigVisible(true);
+        setWantSelectNewLayer(null);
       }
     };
 
@@ -445,7 +459,7 @@ export const LayerControlPanel = memo(
                   originLayerConfig={originLayerConfig}
                   setOriginLayerConfig={setOriginLayerConfig}
                   unsavedModalVisible={unsavedModalVisible}
-                  setUnsavedModalVisible={setUnsavedModalVisible}
+                  setUnsavedModalVisible={updateUnsavedModalVisible}
                 />
               )}
               <AddLayerPanel

--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
@@ -22,6 +22,7 @@ import {
 import { I18nProvider } from '@osd/i18n/react';
 import { Map as Maplibre } from 'maplibre-gl';
 import './layer_control_panel.scss';
+import { isEqual } from 'lodash';
 import { IndexPattern } from '../../../../../src/plugins/data/public';
 import { AddLayerPanel } from '../add_layer_panel';
 import { LayerConfigPanel } from '../layer_config';
@@ -82,6 +83,8 @@ export const LayerControlPanel = memo(
     const [isUpdatingLayerRender, setIsUpdatingLayerRender] = useState(false);
     const [isNewLayer, setIsNewLayer] = useState(false);
     const [isDeleteLayerModalVisible, setIsDeleteLayerModalVisible] = useState(false);
+    const [unsavedModalVisible, setUnsavedModalVisible] = useState(false);
+    const [originLayerConfig, setOriginLayerConfig] = useState<MapLayerSpecification | null>(null);
     const [selectedDeleteLayer, setSelectedDeleteLayer] = useState<
       MapLayerSpecification | undefined
     >();
@@ -174,10 +177,22 @@ export const LayerControlPanel = memo(
       }
     };
 
-    const onClickLayerName = (layer: MapLayerSpecification) => {
-      setSelectedLayerConfig(layer);
-      setIsLayerConfigVisible(true);
+    const hasUnsavedChanges = () => {
+      if (!selectedLayerConfig || !originLayerConfig) {
+        return false;
+      }
+      return isEqual(originLayerConfig, selectedLayerConfig);
     };
+
+    const onClickLayerName = (layer: MapLayerSpecification) => {
+      if (hasUnsavedChanges()) {
+        setUnsavedModalVisible(true);
+      } else {
+        setSelectedLayerConfig(layer);
+        setIsLayerConfigVisible(true);
+      }
+    };
+
     const isLayerExists = (name: string) => {
       return layers.findIndex((layer) => layer.name === name) > -1;
     };
@@ -426,9 +441,11 @@ export const LayerControlPanel = memo(
                   removeLayer={removeLayer}
                   isNewLayer={isNewLayer}
                   setIsNewLayer={setIsNewLayer}
-                  layersIndexPatterns={layersIndexPatterns}
-                  updateIndexPatterns={updateIndexPatterns}
                   isLayerExists={isLayerExists}
+                  originLayerConfig={originLayerConfig}
+                  setOriginLayerConfig={setOriginLayerConfig}
+                  unsavedModalVisible={unsavedModalVisible}
+                  setUnsavedModalVisible={setUnsavedModalVisible}
                 />
               )}
               <AddLayerPanel

--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
@@ -72,6 +72,7 @@ export const LayerControlPanel = memo(
     const { services } = useOpenSearchDashboards<MapServices>();
     const {
       data: { indexPatterns },
+      notifications,
     } = services;
 
     const [isLayerConfigVisible, setIsLayerConfigVisible] = useState(false);
@@ -83,14 +84,10 @@ export const LayerControlPanel = memo(
     const [isUpdatingLayerRender, setIsUpdatingLayerRender] = useState(false);
     const [isNewLayer, setIsNewLayer] = useState(false);
     const [isDeleteLayerModalVisible, setIsDeleteLayerModalVisible] = useState(false);
-    const [unsavedModalVisible, setUnsavedModalVisible] = useState(false);
     const [originLayerConfig, setOriginLayerConfig] = useState<MapLayerSpecification | null>(null);
     const [selectedDeleteLayer, setSelectedDeleteLayer] = useState<
       MapLayerSpecification | undefined
     >();
-    const [wantSelectNewLayer, setWantSelectNewLayer] = useState<MapLayerSpecification | null>(
-      null
-    );
 
     useEffect(() => {
       if (!isUpdatingLayerRender && initialLayersLoaded) {
@@ -189,21 +186,12 @@ export const LayerControlPanel = memo(
 
     const onClickLayerName = (layer: MapLayerSpecification) => {
       if (hasUnsavedChanges()) {
-        setUnsavedModalVisible(true);
-        setWantSelectNewLayer(layer);
+        notifications.toasts.addWarning(
+          `You have unsaved changes for ${selectedLayerConfig?.name}`
+        );
       } else {
         setSelectedLayerConfig(layer);
         setIsLayerConfigVisible(true);
-        setWantSelectNewLayer(null);
-      }
-    };
-
-    const updateUnsavedModalVisible = (visible: boolean) => {
-      setUnsavedModalVisible(visible);
-      if (!visible && wantSelectNewLayer) {
-        setSelectedLayerConfig(wantSelectNewLayer);
-        setIsLayerConfigVisible(true);
-        setWantSelectNewLayer(null);
       }
     };
 
@@ -458,8 +446,6 @@ export const LayerControlPanel = memo(
                   isLayerExists={isLayerExists}
                   originLayerConfig={originLayerConfig}
                   setOriginLayerConfig={setOriginLayerConfig}
-                  unsavedModalVisible={unsavedModalVisible}
-                  setUnsavedModalVisible={updateUnsavedModalVisible}
                 />
               )}
               <AddLayerPanel


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
This PR contains:
- Fixes documents layer data source property not update properly when directly  switch to another layer
- Adds warn modal for unsaved layer configuration when want switch to another layer.

###Demo

https://user-images.githubusercontent.com/90288540/210870457-94cbc36d-0367-4524-9b21-eb644e8e5121.mov



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
