### PR TITLE
Display current visible layers status

### DIFF
--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.scss
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.scss
@@ -15,6 +15,10 @@
     width: $euiSizeL;
   }
 
+  .layerControlPanel__layerTypeIcon {
+    padding-left: $euiSizeM;
+  }
+
   .euiListGroupItem__label {
     width: $euiSizeL * 6;
   }

--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
@@ -30,7 +30,6 @@ import { AddLayerPanel } from '../add_layer_panel';
 import { LayerConfigPanel } from '../layer_config';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import {
-  DASHBOARDS_MAPS_LAYER_TYPE,
   LAYER_ICON_TYPE_MAP,
   LAYER_PANEL_HIDE_LAYER_ICON,
   LAYER_PANEL_SHOW_LAYER_ICON,
@@ -131,9 +130,7 @@ export const LayerControlPanel = memo(
       const getCurrentVisibleLayers = () => {
         return layers.filter(
           (layer: { visibility: string; zoomRange: number[] }) =>
-            layer.visibility === 'visible' &&
-            zoom >= layer.zoomRange[0] &&
-            zoom <= layer.zoomRange[1]
+            zoom >= layer.zoomRange[0] && zoom <= layer.zoomRange[1]
         );
       };
       setVisibleLayers(getCurrentVisibleLayers());
@@ -337,6 +334,10 @@ export const LayerControlPanel = memo(
       }
     };
 
+    const layerIsVisible = (layer: MapLayerSpecification) => {
+      return visibleLayers.includes(layer);
+    };
+
     if (isLayerControlVisible) {
       return (
         <I18nProvider>
@@ -397,18 +398,16 @@ export const LayerControlPanel = memo(
                                 <EuiIcon
                                   size="m"
                                   type={LAYER_ICON_TYPE_MAP[layer.type]}
-                                  color={
-                                    visibleLayers.find((l) => l.id === layer.id)
-                                      ? 'success'
-                                      : '#DDDDDD'
-                                  }
+                                  color={layerIsVisible(layer) ? 'success' : '#DDDDDD'}
                                 />
                               </EuiFlexItem>
                               <EuiFlexItem>
                                 <EuiToolTip
-                                  position="right"
-                                  title={layer.name}
-                                  content={getLayerTooltipContent(layer)}
+                                  position="top"
+                                  title={layerIsVisible(layer) ? '' : layer.name}
+                                  content={
+                                    layerIsVisible(layer) ? '' : getLayerTooltipContent(layer)
+                                  }
                                 >
                                   <EuiListGroupItem
                                     key={layer.id}

--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
@@ -5,19 +5,21 @@
 
 import React, { memo, useEffect, useState } from 'react';
 import {
-  EuiPanel,
-  EuiTitle,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiListGroupItem,
+  DropResult,
   EuiButtonEmpty,
-  EuiHorizontalRule,
   EuiButtonIcon,
+  EuiConfirmModal,
   EuiDragDropContext,
   EuiDraggable,
   EuiDroppable,
-  EuiConfirmModal,
-  DropResult,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiListGroupItem,
+  EuiPanel,
+  EuiTitle,
+  EuiIcon,
+  EuiToolTip,
 } from '@elastic/eui';
 import { I18nProvider } from '@osd/i18n/react';
 import { Map as Maplibre } from 'maplibre-gl';
@@ -28,11 +30,11 @@ import { AddLayerPanel } from '../add_layer_panel';
 import { LayerConfigPanel } from '../layer_config';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import {
-  LAYER_VISIBILITY,
   DASHBOARDS_MAPS_LAYER_TYPE,
   LAYER_ICON_TYPE_MAP,
-  LAYER_PANEL_SHOW_LAYER_ICON,
   LAYER_PANEL_HIDE_LAYER_ICON,
+  LAYER_PANEL_SHOW_LAYER_ICON,
+  LAYER_VISIBILITY,
 } from '../../../common';
 import {
   LayerActions,
@@ -42,8 +44,8 @@ import {
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { MapServices } from '../../types';
 import {
-  handleReferenceLayerRender,
   handleDataLayerRender,
+  handleReferenceLayerRender,
 } from '../../model/layerRenderController';
 import { MapState } from '../../model/mapState';
 
@@ -58,6 +60,7 @@ interface Props {
   layersIndexPatterns: IndexPattern[];
   setLayersIndexPatterns: (indexPatterns: IndexPattern[]) => void;
   mapState: MapState;
+  zoom: number;
 }
 
 export const LayerControlPanel = memo(
@@ -68,6 +71,7 @@ export const LayerControlPanel = memo(
     layersIndexPatterns,
     setLayersIndexPatterns,
     mapState,
+    zoom,
   }: Props) => {
     const { services } = useOpenSearchDashboards<MapServices>();
     const {
@@ -88,6 +92,7 @@ export const LayerControlPanel = memo(
     const [selectedDeleteLayer, setSelectedDeleteLayer] = useState<
       MapLayerSpecification | undefined
     >();
+    const [visibleLayers, setVisibleLayers] = useState<MapLayerSpecification[]>([]);
 
     useEffect(() => {
       if (!isUpdatingLayerRender && initialLayersLoaded) {
@@ -101,10 +106,7 @@ export const LayerControlPanel = memo(
         if (!selectedLayerConfig) {
           return;
         }
-        if (
-          selectedLayerConfig.type === DASHBOARDS_MAPS_LAYER_TYPE.OPENSEARCH_MAP ||
-          selectedLayerConfig.type === DASHBOARDS_MAPS_LAYER_TYPE.CUSTOM_MAP
-        ) {
+        if (referenceLayerTypeLookup[selectedLayerConfig.type]) {
           handleReferenceLayerRender(selectedLayerConfig, maplibreRef, undefined);
         } else {
           updateIndexPatterns();
@@ -124,6 +126,18 @@ export const LayerControlPanel = memo(
       }
       setIsUpdatingLayerRender(false);
     }, [layers]);
+
+    useEffect(() => {
+      const getCurrentVisibleLayers = () => {
+        return layers.filter(
+          (layer: { visibility: string; zoomRange: number[] }) =>
+            layer.visibility === 'visible' &&
+            zoom >= layer.zoomRange[0] &&
+            zoom <= layer.zoomRange[1]
+        );
+      };
+      setVisibleLayers(getCurrentVisibleLayers());
+    }, [layers, zoom]);
 
     // Get layer id from layers that is above the selected layer
     function getMapBeforeLayerId(selectedLayer: MapLayerSpecification): string | undefined {
@@ -315,6 +329,19 @@ export const LayerControlPanel = memo(
       );
     }
 
+    const getLayerTooltipContent = (layer: MapLayerSpecification) => {
+      const tooltipContent = `Layer type: ${layer.type}, Zoom range: ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`;
+      if (layer.type === DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS) {
+        return (
+          tooltipContent +
+          `, Index pattern: ${layer.source.indexPatternRefName}` +
+          `, Geo field: ${layer.source.geoFieldName}`
+        );
+      } else {
+        return tooltipContent;
+      }
+    };
+
     if (isLayerControlVisible) {
       return (
         <I18nProvider>
@@ -366,16 +393,36 @@ export const LayerControlPanel = memo(
                               alignItems="center"
                               gutterSize="none"
                               direction="row"
+                              justifyContent={'flexStart'}
                             >
-                              <EuiFlexItem>
-                                <EuiListGroupItem
-                                  key={layer.id}
-                                  label={layer.name}
-                                  data-item={JSON.stringify(layer)}
-                                  iconType={LAYER_ICON_TYPE_MAP[layer.type]}
-                                  aria-label="layer in the map layers list"
-                                  onClick={() => onClickLayerName(layer)}
+                              <EuiFlexItem
+                                className="layerControlPanel__layerTypeIcon"
+                                grow={false}
+                              >
+                                <EuiIcon
+                                  size="m"
+                                  type={LAYER_ICON_TYPE_MAP[layer.type]}
+                                  color={
+                                    visibleLayers.find((l) => l.id === layer.id)
+                                      ? 'success'
+                                      : '#DDDDDD'
+                                  }
                                 />
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <EuiToolTip
+                                  position="right"
+                                  title={layer.name}
+                                  content={getLayerTooltipContent(layer)}
+                                >
+                                  <EuiListGroupItem
+                                    key={layer.id}
+                                    label={layer.name}
+                                    aria-label="layer in the map layers list"
+                                    onClick={() => onClickLayerName(layer)}
+                                    showToolTip={false}
+                                  />
+                                </EuiToolTip>
                               </EuiFlexItem>
                               <EuiFlexGroup justifyContent="flexEnd" gutterSize="none">
                                 <EuiFlexItem

--- a/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/maps_dashboards/public/components/layer_control_panel/layer_control_panel.tsx
@@ -330,15 +330,10 @@ export const LayerControlPanel = memo(
     }
 
     const getLayerTooltipContent = (layer: MapLayerSpecification) => {
-      const tooltipContent = `Layer type: ${layer.type}, Zoom range: ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`;
-      if (layer.type === DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS) {
-        return (
-          tooltipContent +
-          `, Index pattern: ${layer.source.indexPatternRefName}` +
-          `, Geo field: ${layer.source.geoFieldName}`
-        );
+      if (zoom < layer.zoomRange[0] || zoom > layer.zoomRange[1]) {
+        return `Layer is not visible outside of zoom range ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`;
       } else {
-        return tooltipContent;
+        return `Layer is visible within zoom range ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`;
       }
     };
 

--- a/maps_dashboards/public/components/map_container/map_container.tsx
+++ b/maps_dashboards/public/components/map_container/map_container.tsx
@@ -144,6 +144,7 @@ export const MapContainer = ({
             layersIndexPatterns={layersIndexPatterns}
             setLayersIndexPatterns={setLayersIndexPatterns}
             mapState={mapState}
+            zoom={zoom}
           />
         )}
       </div>


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Display current visible layer information on the layer control panel. 
- When the layer zoom range in current zoom level, its layer icon will be colorful, else it will be text color.
- When the layer zoom range is out of current zoom level, move mouse to layer name, the tooltip will show it's out of zoom range.

### Demo

https://user-images.githubusercontent.com/90288540/211118787-b7532b72-ebd9-4cb5-a9f1-079fa69631a7.mov



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
