### PR TITLE
Update zoom range render logic

### DIFF
--- a/public/model/customLayerFunctions.ts
+++ b/public/model/customLayerFunctions.ts
@@ -71,6 +71,11 @@ const addNewLayer = (
       },
       beforeMbLayerId
     );
+    maplibreInstance.setLayerZoomRange(
+      layerConfig.id,
+      layerConfig.zoomRange[0],
+      layerConfig.zoomRange[1]
+    );
   }
 };
 

--- a/public/model/documentLayerFunctions.ts
+++ b/public/model/documentLayerFunctions.ts
@@ -149,6 +149,11 @@ const addNewLayer = (
       beforeId
     );
     maplibreInstance?.setLayoutProperty(lineLayerId, 'visibility', documentLayerConfig.visibility);
+    maplibreInstance?.setLayerZoomRange(
+      lineLayerId,
+      documentLayerConfig.zoomRange[0],
+      documentLayerConfig.zoomRange[1]
+    );
   };
 
   const addCircleLayer = (
@@ -177,6 +182,11 @@ const addNewLayer = (
       'visibility',
       documentLayerConfig.visibility
     );
+    maplibreInstance?.setLayerZoomRange(
+      circleLayerId,
+      documentLayerConfig.zoomRange[0],
+      documentLayerConfig.zoomRange[1]
+    );
   };
 
   const addFillLayer = (
@@ -198,6 +208,11 @@ const addNewLayer = (
       beforeId
     );
     maplibreInstance?.setLayoutProperty(fillLayerId, 'visibility', documentLayerConfig.visibility);
+    maplibreInstance?.setLayerZoomRange(
+      fillLayerId,
+      documentLayerConfig.zoomRange[0],
+      documentLayerConfig.zoomRange[1]
+    );
     // Due to limitations on WebGL, fill can't render outlines with width wider than 1,
     // so we have to create another style layer with type=line to apply width.
     const outlineId = buildLayerSuffix(documentLayerConfig.id, 'fill-outline');
@@ -216,6 +231,11 @@ const addNewLayer = (
       beforeId
     );
     maplibreInstance?.setLayoutProperty(outlineId, 'visibility', layerConfig.visibility);
+    maplibreInstance?.setLayerZoomRange(
+      outlineId,
+      documentLayerConfig.zoomRange[0],
+      documentLayerConfig.zoomRange[1]
+    );
   };
 
   if (maplibreInstance) {


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Fix the issue when open saved map, zoom range can't load for documents layer and custom layer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
