### PR TITLE
Update layer type UI on config panel

### DIFF
--- a/public/components/layer_config/layer_basic_settings.tsx
+++ b/public/components/layer_config/layer_basic_settings.tsx
@@ -99,14 +99,6 @@ export const LayerBasicSettings = ({
       </EuiTitle>
       <EuiSpacer size="m" />
       <EuiForm>
-        <EuiFormRow label="Type" fullWidth={true}>
-          <EuiFieldText
-            name="layerType"
-            value={layersTypeNameMap[selectedLayerConfig.type]}
-            readOnly={true}
-            fullWidth={true}
-          />
-        </EuiFormRow>
         <EuiFormRow label="Name" error={errors} isInvalid={invalid} fullWidth={true}>
           <EuiFieldText
             name="layerName"

--- a/public/components/layer_config/layer_config_panel.tsx
+++ b/public/components/layer_config/layer_config_panel.tsx
@@ -21,13 +21,14 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiIcon,
+  EuiSpacer,
 } from '@elastic/eui';
 
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import { BaseMapLayerConfigPanel } from './index';
 import { DASHBOARDS_MAPS_LAYER_TYPE } from '../../../common';
 import { DocumentLayerConfigPanel } from './documents_config/document_layer_config_panel';
-import { layersTypeIconMap } from '../../model/layersFunctions';
+import { layersTypeIconMap, layersTypeNameMap } from '../../model/layersFunctions';
 import { CustomMapConfigPanel } from './custom_map_config/custom_map_config_panel';
 
 interface Props {
@@ -104,12 +105,18 @@ export const LayerConfigPanel = ({
       className="layerConfigPanel"
     >
       <EuiFlyoutHeader hasBorder={true}>
-        <EuiFlexGroup gutterSize="s" justifyContent="spaceAround">
+        <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiIcon type={layersTypeIconMap[selectedLayerConfig.type]} size="m" />
           </EuiFlexItem>
           <EuiFlexItem>
             <strong>{selectedLayerConfig.name}</strong>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="s" />
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <small>Type: {layersTypeNameMap[selectedLayerConfig.type]}</small>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutHeader>


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Move layer type UI on config panel from panel body Input to header, we got input from UX that the existing uneditable Input to display layer type may be confused on UI.

Before:
<img width="445" alt="image" src="https://user-images.githubusercontent.com/90288540/211635895-a26d0b72-e514-4d36-990b-ed3f7011e515.png">



After:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/90288540/211635793-1de462d0-4659-4b1e-b22e-10713c8d1fdb.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
