### PR TITLE
Move maps entrypoint under plugins

### DIFF
--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -32,7 +32,11 @@ export class CustomImportMapPlugin
     core.application.register({
       id: PLUGIN_NAVIGATION_BAR_ID,
       title: PLUGIN_NAVIGATION_BAR_TILE,
-      category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
+      category: {
+        id: 'opensearch',
+        label: 'OpenSearch Plugins',
+        order: 2000,
+      },
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application');

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -32,6 +32,7 @@ export class CustomImportMapPlugin
     core.application.register({
       id: PLUGIN_NAVIGATION_BAR_ID,
       title: PLUGIN_NAVIGATION_BAR_TILE,
+      order: 5100,
       category: {
         id: 'opensearch',
         label: 'OpenSearch Plugins',


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Move maps entrypoint under plugins. Finally It will be at above notifications, below anomaly detection plugin.

<img width="381" alt="image" src="https://user-images.githubusercontent.com/90288540/211672895-f04f0a60-90bc-48fb-8bba-5798d2b8a7a6.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
