### PR TITLE
[2.5] Add OpenSearch Dashboards context to component and common folder …

### DIFF
--- a/.opensearch_dashboards-plugin-helpers.json
+++ b/.opensearch_dashboards-plugin-helpers.json
@@ -1,0 +1,10 @@
+{
+  "serverSourcePatterns": [
+    "package.json",
+    "tsconfig.json",
+    "yarn.lock",
+    ".yarnrc",
+    "{lib,public,server,webpackShims,translations,utils,models,test,common}/**/*",
+    "!__tests__"
+  ]
+}

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -8,7 +8,6 @@ import {
   AppMountParameters,
   CoreSetup,
   CoreStart,
-  DEFAULT_APP_CATEGORIES,
   Plugin,
   PluginInitializerContext,
 } from '../../../src/core/public';
@@ -24,10 +23,10 @@ import {
   PLUGIN_NAVIGATION_BAR_TILE,
 } from '../common/constants/shared';
 import { ConfigSchema } from '../common/config';
-
 import { AppPluginSetupDependencies } from './types';
 import { RegionMapVisualizationDependencies } from '../../../src/plugins/region_map/public';
 import { VectorUploadOptions } from './components/vector_upload_options';
+import { OpenSearchDashboardsContextProvider } from '../../../src/plugins/opensearch_dashboards_react/public';
 
 export class CustomImportMapPlugin
   implements Plugin<CustomImportMapPluginSetup, CustomImportMapPluginStart> {
@@ -80,13 +79,21 @@ export class CustomImportMapPlugin
       },
     });
 
-    regionMap.addOptionTab({
-      name: 'controls',
-      title: i18n.translate('regionMap.mapVis.regionMapEditorConfig.controlTabs.controlsTitle', {
-        defaultMessage: 'Import Vector Map',
-      }),
-      editor: (props: RegionMapVisualizationDependencies) => <VectorUploadOptions {...props} />,
-    });
+    const customSetup = async () => {
+      const [coreStart] = await core.getStartServices();
+      regionMap.addOptionTab({
+        name: 'controls',
+        title: i18n.translate('regionMap.mapVis.regionMapEditorConfig.controlTabs.controlsTitle', {
+          defaultMessage: 'Import Vector Map',
+        }),
+        editor: (props: RegionMapVisualizationDependencies) => (
+          <OpenSearchDashboardsContextProvider services={coreStart}>
+            <VectorUploadOptions {...props} />
+          </OpenSearchDashboardsContextProvider>
+        ),
+      });
+    };
+    customSetup();
 
     // Return methods that should be available to other plugins
     return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,7 @@
     "types": ["node", "jest", "react"]
   },
   "include": [
+    "common/**/*",
     "server/**/*",
     "public/**/*",
     "utils/**/*",


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Add OpenSearch Dashboards context to component and common folder changes. There was the same code change [PR](https://github.com/opensearch-project/dashboards-maps/pull/34) was merged to 2.2, and 2.x. but didn’t merge to main.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
