### PR TITLE
[Cypress fix] Wait map saved before open maps listing

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -118,7 +118,7 @@ jobs:
       # Window is slow so wait longer
       - name: Sleep until OSD server starts - windows
         if: ${{ matrix.os == 'windows-latest' }}
-        run: Start-Sleep -s 400
+        run: Start-Sleep -s 600
         shell: powershell
 
       - name: Sleep until OSD server starts - non-windows

--- a/cypress/integration/documentsLayer.spec.js
+++ b/cypress/integration/documentsLayer.spec.js
@@ -45,6 +45,7 @@ describe('Documents layer', () => {
     cy.wait(5000).get('[data-test-subj="top-nav"]').click();
     cy.wait(5000).get('[data-test-subj="savedObjectTitle"]').type(uniqueName);
     cy.wait(5000).get('[data-test-subj="confirmSaveSavedObjectButton"]').click();
+    cy.wait(5000).get('[data-test-subj="breadcrumb last"]').should('contain', uniqueName);
   });
 
   it('Open saved map with documents layer', () => {


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Wait map saved before redirect to maps listing page, so that void not able to find saved map in listing page. This issue only happens in GH action cypress CI window OS.

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/210


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
