### PR TITLE
Fix popup display while zoomed out

### DIFF
--- a/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/public/components/layer_control_panel/layer_control_panel.tsx
@@ -36,7 +36,6 @@ import {
   LAYER_VISIBILITY,
 } from '../../../common';
 import {
-  LayerActions,
   layersFunctionMap,
   referenceLayerTypeLookup,
 } from '../../model/layersFunctions';

--- a/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/public/components/layer_control_panel/layer_control_panel.tsx
@@ -35,10 +35,7 @@ import {
   LAYER_PANEL_SHOW_LAYER_ICON,
   LAYER_VISIBILITY,
 } from '../../../common';
-import {
-  layersFunctionMap,
-  referenceLayerTypeLookup,
-} from '../../model/layersFunctions';
+import { referenceLayerTypeLookup } from '../../model/layersFunctions';
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { MapServices } from '../../types';
 import {
@@ -47,7 +44,7 @@ import {
 } from '../../model/layerRenderController';
 import { MapState } from '../../model/mapState';
 import { ConfigSchema } from '../../../common/config';
-import {moveLayers, removeLayers, updateLayerVisibility} from "../../model/map/layer_operations";
+import { moveLayers, removeLayers, updateLayerVisibility } from '../../model/map/layer_operations';
 
 interface MaplibreRef {
   current: Maplibre | null;

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -13,7 +13,7 @@ import { MAP_INITIAL_STATE, DASHBOARDS_MAPS_LAYER_TYPE } from '../../../common';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import { IndexPattern } from '../../../../../src/plugins/data/public';
 import { MapState } from '../../model/mapState';
-import {createPopup, getPopupLngLat, getPopupLocation, isTooltipEnabledLayer} from '../tooltip/create_tooltip';
+import { createPopup, getPopupLocation, isTooltipEnabledLayer } from '../tooltip/create_tooltip';
 import { handleDataLayerRender } from '../../model/layerRenderController';
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { MapServices } from '../../types';
@@ -167,7 +167,13 @@ export const MapContainer = ({
 
   return (
     <div>
-      <EuiPanel hasShadow={false} hasBorder={false} color="transparent" className="zoombar" data-test-subj="mapStatusBar">
+      <EuiPanel
+        hasShadow={false}
+        hasBorder={false}
+        color="transparent"
+        className="zoombar"
+        data-test-subj="mapStatusBar"
+      >
         <small>
           {coordinates &&
             `lat: ${coordinates.lat.toFixed(4)}, lon: ${coordinates.lng.toFixed(4)}, `}

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -13,7 +13,7 @@ import { MAP_INITIAL_STATE, DASHBOARDS_MAPS_LAYER_TYPE } from '../../../common';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import { IndexPattern } from '../../../../../src/plugins/data/public';
 import { MapState } from '../../model/mapState';
-import { createPopup, getPopupLngLat, isTooltipEnabledLayer } from '../tooltip/create_tooltip';
+import {createPopup, getPopupLngLat, getPopupLocation, isTooltipEnabledLayer} from '../tooltip/create_tooltip';
 import { handleDataLayerRender } from '../../model/layerRenderController';
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { MapServices } from '../../types';
@@ -86,7 +86,7 @@ export const MapContainer = ({
       if (features && maplibreRef.current) {
         clickPopup = createPopup({ features, layers: tooltipEnabledLayers });
         clickPopup
-          ?.setLngLat(getPopupLngLat(features[0].geometry) ?? e.lngLat)
+          ?.setLngLat(getPopupLocation(features[0].geometry, e.lngLat))
           .addTo(maplibreRef.current);
       }
     }
@@ -108,7 +108,7 @@ export const MapContainer = ({
           showLayerSelection: false,
         });
         hoverPopup
-          ?.setLngLat(getPopupLngLat(features[0].geometry) ?? e.lngLat)
+          ?.setLngLat(getPopupLocation(features[0].geometry, e.lngLat))
           .addTo(maplibreRef.current);
       }
     }

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -92,6 +92,7 @@ export const MapContainer = ({
     }
 
     function onMouseMoveMap(e: MapEventType['mousemove']) {
+      // This is required to update coordinates on map only on mouse move
       setCoordinates(e.lngLat.wrap());
 
       // remove previous popup

--- a/public/components/tooltip/create_tooltip.tsx
+++ b/public/components/tooltip/create_tooltip.tsx
@@ -46,9 +46,8 @@ export function getPopupLngLat(geometry: GeoJSON.Geometry) {
   // use mouse position should be better
   if (geometry.type === 'Point') {
     return [geometry.coordinates[0], geometry.coordinates[1]] as [number, number];
-  } else {
-    return null;
   }
+  return null;
 }
 
 export function createPopup({

--- a/public/components/tooltip/create_tooltip.tsx
+++ b/public/components/tooltip/create_tooltip.tsx
@@ -19,7 +19,8 @@ export function isTooltipEnabledLayer(
   return (
     layer.type !== 'opensearch_vector_tile_map' &&
     layer.type !== 'custom_map' &&
-    layer.source.showTooltips === true
+    layer.source.showTooltips === true &&
+    !!layer.source.tooltipFields?.length
   );
 }
 

--- a/public/components/tooltip/create_tooltip.tsx
+++ b/public/components/tooltip/create_tooltip.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Popup, MapGeoJSONFeature, MapEventType, LngLat } from 'maplibre-gl';
+import { Popup, MapGeoJSONFeature, LngLat } from 'maplibre-gl';
 
 import { MapLayerSpecification, DocumentLayerSpecification } from '../../model/mapLayerType';
 import { FeatureGroupItem, TooltipContainer } from './tooltipContainer';
+import {MAX_LONGITUDE} from "../../../common";
 
 interface Options {
   features: MapGeoJSONFeature[];
@@ -40,16 +41,6 @@ export function groupFeaturesByLayers(
   return featureGroups;
 }
 
-export function getPopupLngLat(geometry: GeoJSON.Geometry) {
-  // geometry.coordinates is different for different geometry.type, here we use the geometry.coordinates
-  // of a Point as the position of the popup. For other types, such as Polygon, MultiPolygon, etc,
-  // use mouse position should be better
-  if (geometry.type === 'Point') {
-    return [geometry.coordinates[0], geometry.coordinates[1]] as [number, number];
-  }
-  return null;
-}
-
 export function getPopupLocation(geometry: GeoJSON.Geometry, mousePoint: LngLat) {
   // geometry.coordinates is different for different geometry.type, here we use the geometry.coordinates
   // of a Point as the position of the popup. For other types, such as Polygon, MultiPolygon, etc,
@@ -58,10 +49,11 @@ export function getPopupLocation(geometry: GeoJSON.Geometry, mousePoint: LngLat)
     return mousePoint;
   }
   const coordinates = geometry.coordinates;
+  // Copied from https://maplibre.org/maplibre-gl-js-docs/example/popup-on-click/
   // Ensure that if the map is zoomed out such that multiple
   // copies of the feature are visible, the popup appears
   // over the copy being pointed to.
-  while (Math.abs(mousePoint.lng - coordinates[0]) > 180) {
+  while (Math.abs(mousePoint.lng - coordinates[0]) > MAX_LONGITUDE) {
     coordinates[0] += mousePoint.lng > coordinates[0] ? 360 : -360;
   }
   return [coordinates[0], coordinates[1]] as [number, number];


### PR DESCRIPTION
### Description
While zoom out, maps will have multiple copies of world map. Before this fix, popup will be displayed always at first copy even if users are hovering over another copy. This will make sure that hover shows up on where pointer is hovered.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
