### PR TITLE
Fix flaky test on cypress ci

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -115,7 +115,6 @@ jobs:
           yarn start --no-base-path --no-watch &
         shell: bash
 
-      # Window is slow so wait longer
       - name: Sleep until OSD server starts - windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: Start-Sleep -s 600
@@ -123,7 +122,7 @@ jobs:
 
       - name: Sleep until OSD server starts - non-windows
         if: ${{ matrix.os != 'windows-latest' }}
-        run: sleep 400
+        run: sleep 600
         shell: bash
 
       - name: Install Cypress


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Add more wait time for OSD start run to fix flaky test on cypress ci

https://github.com/opensearch-project/dashboards-maps/actions/runs/4120910890/jobs/7116107984


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
