### PR TITLE
Add maps saved object for sample datasets

### DIFF
--- a/cypress/integration/add_saved_object.spec.js
+++ b/cypress/integration/add_saved_object.spec.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_PATH } from '../utils/constants';
+
+describe('Add flights dataset saved object', () => {
+  before(() => {
+    cy.visit(`${BASE_PATH}/app/maps-dashboards`, {
+      retryOnStatusCodeFailure: true,
+      timeout: 60000,
+    });
+    cy.get('div[data-test-subj="indexPatternEmptyState"]', { timeout: 60000 })
+      .contains(/Add sample data/)
+      .click();
+    cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
+      .contains(/Add data/)
+      .click();
+    cy.wait(60000);
+  });
+
+  it('check if maps saved object of flights dataset can be found and open', () => {
+    cy.visit(`${BASE_PATH}/app/maps-dashboards`);
+    cy.contains('[Flights] Maps Cancelled Flights Destination Location').click();
+    cy.get('[data-test-subj="layerControlPanel"]').should('contain', 'Cancelled flights');
+  });
+
+  after(() => {
+    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
+      retryOnStatusCodeFailure: true,
+      timeout: 60000,
+    });
+    cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
+      .contains(/Remove/)
+      .click();
+    cy.wait(60000);
+  });
+});

--- a/cypress/integration/add_saved_object.spec.js
+++ b/cypress/integration/add_saved_object.spec.js
@@ -20,14 +20,14 @@ describe('Add flights dataset saved object', () => {
     cy.wait(60000);
   });
 
+  after(() => {
+    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
+    cy.get('button[data-test-subj="removeSampleDataSetflights"]').should('be.visible').click();
+  });
+
   it('check if maps saved object of flights dataset can be found and open', () => {
     cy.visit(`${BASE_PATH}/app/maps-dashboards`);
     cy.contains('[Flights] Maps Cancelled Flights Destination Location').click();
     cy.get('[data-test-subj="layerControlPanel"]').should('contain', 'Cancelled flights');
-  });
-
-  after(() => {
-    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
-    cy.get('button[data-test-subj="removeSampleDataSetflights"]').should('be.visible').click();
   });
 });

--- a/cypress/integration/add_saved_object.spec.js
+++ b/cypress/integration/add_saved_object.spec.js
@@ -27,13 +27,7 @@ describe('Add flights dataset saved object', () => {
   });
 
   after(() => {
-    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
-      retryOnStatusCodeFailure: true,
-      timeout: 60000,
-    });
-    cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
-      .contains(/Remove/)
-      .click();
-    cy.wait(60000);
+    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
+    cy.get('button[data-test-subj="removeSampleDataSetflights"]').should('be.visible').click();
   });
 });

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -5,5 +5,5 @@
     "server": true,
     "ui": true,
     "requiredPlugins": ["regionMap", "opensearchDashboardsReact", "navigation", "savedObjects", "data"],
-    "optionalPlugins": []
+    "optionalPlugins": ["home"]
   }

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -39,7 +39,8 @@ export class CustomImportMapPlugin
     this.config$ = initializerContext.config.create<ConfigSchema>();
   }
 
-  addMapsSavedObjects(home: HomeServerPluginSetup, config: ConfigSchema) {
+  // Adds dashboards-maps saved objects to existing sample datasets using home plugin
+  private addMapsSavedObjects(home: HomeServerPluginSetup, config: ConfigSchema) {
     home.sampleData.addSavedObjectsToSampleDataset('flights', getFlightsSavedObjects(config));
   }
 
@@ -48,7 +49,7 @@ export class CustomImportMapPlugin
     // @ts-ignore
     const globalConfig = await this.globalConfig$.pipe(first()).toPromise();
     // @ts-ignore
-    const config = await this.config$.pipe(first()).toPromise() as ConfigSchema;
+    const config = (await this.config$.pipe(first()).toPromise()) as ConfigSchema;
 
     const geospatialClient = createGeospatialCluster(core, globalConfig);
     // Initialize services
@@ -57,10 +58,6 @@ export class CustomImportMapPlugin
 
     const router = core.http.createRouter();
     const { home } = plugins;
-    // const mapConfig = configSchema;
-    // const mapConfig: ConfigSchema = {
-    //   ...this._initializerContext.config.get<ConfigSchema>(),
-    // };
 
     // Register server side APIs
     geospatial(geospatialService, router);

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -63,13 +63,13 @@ export class CustomImportMapPlugin
     geospatial(geospatialService, router);
     opensearch(opensearchService, router);
 
-    if (home) this.addMapsSavedObjects(home, config);
-
     // Register saved object types
     core.savedObjects.registerType(mapSavedObjectsType);
 
     // Register capabilities
     core.capabilities.registerProvider(capabilitiesProvider);
+
+    if (home) this.addMapsSavedObjects(home, config);
 
     return {};
   }

--- a/server/services/sample_data/flights_saved_objects.ts
+++ b/server/services/sample_data/flights_saved_objects.ts
@@ -6,7 +6,7 @@
 // import { SavedObject } from 'opensearch-dashboards/server';
 
 import { i18n } from '@osd/i18n';
-// import { ConfigSchema } from '../../../common/config';
+import { ConfigSchema } from '../../../common/config';
 
 // const layerList = (mapConfig: ConfigSchema) => [
 
@@ -75,7 +75,9 @@ const layerList = [
   },
 ];
 
-export const getFlightsSavedObjects = () => {
+export const getFlightsSavedObjects = (config: ConfigSchema) => {
+  console.log('CONFIGVALUES:')
+  console.log(JSON.stringify(config, null, 2));
   return [
     {
       id: '122713b0-9e70-11ed-9463-35a6f30dbef6',

--- a/server/services/sample_data/flights_saved_objects.ts
+++ b/server/services/sample_data/flights_saved_objects.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// import { SavedObject } from 'opensearch-dashboards/server';
+
+import { i18n } from '@osd/i18n';
+// import { ConfigSchema } from '../../../common/config';
+
+// const layerList = (mapConfig: ConfigSchema) => [
+
+// const urls = (mapConfig: ConfigSchema) => ({
+//   dataUrl: mapConfig.opensearchVectorTileDataUrl,
+//   styleUrl: mapConfig.opensearchVectorTileStyleUrl,
+// });
+const layerList = [
+  {
+    name: 'Default map',
+    description: '',
+    type: 'opensearch_vector_tile_map',
+    id: 'cad56fcc-be02-43ea-a1a6-1d17f437acf7',
+    zoomRange: [0, 22],
+    opacity: 100,
+    visibility: 'visible',
+    source: {
+      dataURL: 'https://tiles.maps.opensearch.org/data/v1.json',
+    },
+    style: {
+      styleURL: 'https://tiles.maps.opensearch.org/styles/basic.json',
+    },
+  },
+  {
+    name: 'Cancelled flights',
+    description: 'Shows cancelled flights',
+    type: 'documents',
+    id: 'f3ae28ce-2494-4e50-ae31-4603cfcbfd7d',
+    zoomRange: [2, 22],
+    opacity: 70,
+    visibility: 'visible',
+    source: {
+      indexPatternRefName: 'opensearch_dashboards_sample_data_flights',
+      geoFieldType: 'geo_point',
+      geoFieldName: 'DestLocation',
+      documentRequestNumber: 1000,
+      tooltipFields: ['Carrier', 'Cancelled'],
+      showTooltips: true,
+      indexPatternId: 'd3d7af60-4c81-11e8-b3d7-01146121b73d',
+      useGeoBoundingBoxFilter: true,
+      filters: [
+        {
+          meta: {
+            index: 'd3d7af60-4c81-11e8-b3d7-01146121b73d',
+            alias: null,
+            negate: false,
+            disabled: false,
+          },
+          query: {
+            match_phrase: {
+              Cancelled: true,
+            },
+          },
+          $state: {
+            store: 'appState',
+          },
+        },
+      ],
+    },
+    style: {
+      fillColor: '#CA8EAE',
+      borderColor: '#CA8EAE',
+      borderThickness: 1,
+      markerSize: 5,
+    },
+  },
+];
+
+export const getFlightsSavedObjects = () => {
+  return [
+    {
+      id: '122713b0-9e70-11ed-9463-35a6f30dbef6',
+      type: 'map',
+      updated_at: '2023-01-27T18:26:09.643Z',
+      version: 'WzIzLDFd',
+      migrationVersion: {},
+      attributes: {
+        title: i18n.translate('home.sampleData.flightsSpec.mapsCancelledFlights', {
+          defaultMessage: '[Flights] Maps Cancelled Flights Destination Location',
+        }),
+        description: 'Sample map to show cancelled flights location at destination',
+        layerList: JSON.stringify(layerList),
+        mapState:
+          '{"timeRange":{"from":"now-15d","to":"now"},"query":{"query":"","language":"kuery"},"refreshInterval":{"pause":true,"value":12000}}',
+      },
+      references: [],
+    },
+  ];
+};

--- a/server/services/sample_data/flights_saved_objects.ts
+++ b/server/services/sample_data/flights_saved_objects.ts
@@ -3,18 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// import { SavedObject } from 'opensearch-dashboards/server';
-
 import { i18n } from '@osd/i18n';
 import { ConfigSchema } from '../../../common/config';
 
-// const layerList = (mapConfig: ConfigSchema) => [
-
-// const urls = (mapConfig: ConfigSchema) => ({
-//   dataUrl: mapConfig.opensearchVectorTileDataUrl,
-//   styleUrl: mapConfig.opensearchVectorTileStyleUrl,
-// });
-const layerList = [
+const layerList = (config: ConfigSchema) => [
   {
     name: 'Default map',
     description: '',
@@ -24,10 +16,10 @@ const layerList = [
     opacity: 100,
     visibility: 'visible',
     source: {
-      dataURL: 'https://tiles.maps.opensearch.org/data/v1.json',
+      dataURL: config.opensearchVectorTileDataUrl,
     },
     style: {
-      styleURL: 'https://tiles.maps.opensearch.org/styles/basic.json',
+      styleURL: config.opensearchVectorTileStyleUrl,
     },
   },
   {
@@ -76,8 +68,6 @@ const layerList = [
 ];
 
 export const getFlightsSavedObjects = (config: ConfigSchema) => {
-  console.log('CONFIGVALUES:')
-  console.log(JSON.stringify(config, null, 2));
   return [
     {
       id: '122713b0-9e70-11ed-9463-35a6f30dbef6',
@@ -90,7 +80,7 @@ export const getFlightsSavedObjects = (config: ConfigSchema) => {
           defaultMessage: '[Flights] Maps Cancelled Flights Destination Location',
         }),
         description: 'Sample map to show cancelled flights location at destination',
-        layerList: JSON.stringify(layerList),
+        layerList: JSON.stringify(layerList(config)),
         mapState:
           '{"timeRange":{"from":"now-15d","to":"now"},"query":{"query":"","language":"kuery"},"refreshInterval":{"pause":true,"value":12000}}',
       },

--- a/server/types.ts
+++ b/server/types.ts
@@ -2,8 +2,13 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { HomeServerPluginSetup } from '../../../src/plugins/home/server';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CustomImportMapPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CustomImportMapPluginStart {}
+
+export interface AppPluginSetupDependencies {
+  home?: HomeServerPluginSetup;
+}


### PR DESCRIPTION
### Description
This PR includes the changes which adds the dashboards-maps saved object to the existing sample dataset. When the user install a sample dataset then in the dashboards-maps panel, we can see a default saved map which will help maps users to explore maps with that dataset instead of creating a new map from scratch.

We have two videos below which shows the dashboards-maps panel before adding these changes and after adding these changes for flights sample dataset. Similarly, we can add saved objects for other sample datasets. 

https://user-images.githubusercontent.com/89161683/218019859-c7a7f575-ddb1-4afa-807a-a07c43507dd1.mov

https://user-images.githubusercontent.com/89161683/218020002-38131051-953f-49fa-ac1f-695e0ccd92e5.mov

#### Testing
Tested it to make sure the saved object consumes the latest changes in config(dataUrl and styleUrl):
1. Firstly, without makes any changes to config values, such that it consumes default values from [config.ts](https://github.com/opensearch-project/dashboards-maps/blob/main/common/config.ts)
2. Passing it as a command line argument
```
yarn start --custom_import_map_dashboards.opensearchVectorTileDataUrl="...."
```
3. Setting it's value in the `config/opensearch_dashboards.yml`

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3244 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
