### PR TITLE
Align items in add new layer modal

### DIFF
--- a/public/components/add_layer_panel/add_layer_panel.scss
+++ b/public/components/add_layer_panel/add_layer_panel.scss
@@ -8,5 +8,18 @@
 }
 
 .addLayerDialog__description {
-  width: 272px;
+  width: 16 * $euiSizeM;
+}
+
+.addLayer__types {
+  width: 5 * $euiSizeL;
+  height: 5 * $euiSizeL;
+}
+
+.addLayer__modalBody {
+  padding: 0;
+
+  .addLayer__selection {
+    width: 10 * $euiSizeL
+  }
 }

--- a/public/components/add_layer_panel/add_layer_panel.tsx
+++ b/public/components/add_layer_panel/add_layer_panel.tsx
@@ -19,6 +19,7 @@ import {
   EuiKeyPadMenuItem,
   EuiSpacer,
   EuiText,
+  EuiKeyPadMenu,
 } from '@elastic/eui';
 import './add_layer_panel.scss';
 import {
@@ -77,6 +78,7 @@ export const AddLayerPanel = ({
         onMouseEnter={() => setHighlightItem(layerItem)}
         onMouseLeave={() => setHighlightItem(null)}
         onBlur={() => setHighlightItem(null)}
+        className={'addLayer__types'}
       >
         <EuiIcon type={layerItem.icon} size="xl" color="secondary" />
       </EuiKeyPadMenuItem>
@@ -95,6 +97,7 @@ export const AddLayerPanel = ({
         onMouseEnter={() => setHighlightItem(layerItem)}
         onMouseLeave={() => setHighlightItem(null)}
         onBlur={() => setHighlightItem(null)}
+        className="addLayer__types"
       >
         <EuiIcon type={layerItem.icon} size="xl" color="secondary" />
       </EuiKeyPadMenuItem>
@@ -141,27 +144,24 @@ export const AddLayerPanel = ({
               <h2>Add layer</h2>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
-          <EuiModalBody>
+          <EuiModalBody className="addLayer__modalBody">
             <EuiFlexGroup>
-              <EuiFlexItem>
+              <EuiFlexItem className="addLayer__selection">
                 <EuiTitle size="s">
                   <h6>Data layer</h6>
                 </EuiTitle>
-                <EuiSpacer size="s" />
-                <EuiFlexGroup gutterSize="xs">{dataLayerItems}</EuiFlexGroup>
-                <EuiSpacer size="s" />
+                <EuiKeyPadMenu>{dataLayerItems}</EuiKeyPadMenu>
                 <EuiHorizontalRule margin="xs" />
+                <EuiSpacer size="m" />
                 <EuiTitle size="s">
                   <h6>Base layer</h6>
                 </EuiTitle>
-                <EuiSpacer size="s" />
-                <EuiFlexGroup gutterSize="xs">{baseLayersItems}</EuiFlexGroup>
+                <EuiKeyPadMenu>{baseLayersItems}</EuiKeyPadMenu>
               </EuiFlexItem>
               <EuiFlexItem className="addLayerDialog__description">
                 <EuiTitle size="s">
                   <h6>{highlightItem?.name ? highlightItem.name : 'Select a layer type'}</h6>
                 </EuiTitle>
-                <EuiSpacer size="m" />
                 <EuiText>
                   {highlightItem?.description
                     ? highlightItem.description


### PR DESCRIPTION
### Description
Align different type layer items in the add new layer modal.

Before:
<img width="658" alt="image" src="https://user-images.githubusercontent.com/90288540/219826307-db58b401-5d07-4073-a9d0-c5be4ff072a6.png">


After:
<img width="618" alt="image" src="https://user-images.githubusercontent.com/90288540/219826292-fb9b1ada-8c89-488b-b4b9-9243099b1956.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
