### PR TITLE
Add close button to tooltip hover

### DIFF
--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -103,7 +103,8 @@ export const MapContainer = ({
         hoverPopup = createPopup({
           features,
           layers: tooltipEnabledLayers,
-          showCloseButton: false,
+          // enable close button to avoid occasional dangling tooltip that is not cleared during mouse leave action
+          showCloseButton: true,
           showPagination: false,
           showLayerSelection: false,
         });

--- a/public/components/tooltip/create_tooltip.tsx
+++ b/public/components/tooltip/create_tooltip.tsx
@@ -4,7 +4,7 @@ import { Popup, MapGeoJSONFeature, LngLat } from 'maplibre-gl';
 
 import { MapLayerSpecification, DocumentLayerSpecification } from '../../model/mapLayerType';
 import { FeatureGroupItem, TooltipContainer } from './tooltipContainer';
-import {MAX_LONGITUDE} from "../../../common";
+import { MAX_LONGITUDE } from '../../../common';
 
 interface Options {
   features: MapGeoJSONFeature[];


### PR DESCRIPTION
### Description
When large number of points and shapes are rendered on same location, tooltip occasionally is not cleared. 
Adding close button will solve this problem temporarily to unblock users have to reload map to get rid of dangling tooltip contents.

### Issues Resolved
#259 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
