### PR TITLE
Refactor layer handler into parent component

### DIFF
--- a/public/components/layer_config/documents_config/document_layer_config_panel.tsx
+++ b/public/components/layer_config/documents_config/document_layer_config_panel.tsx
@@ -55,7 +55,7 @@ export const DocumentLayerConfigPanel = (props: Props) => {
           <DocumentLayerSource {...newProps} />
         </Fragment>
       ),
-      testSubj: 'dataTab',
+      testsubj: 'dataTab',
     },
     {
       id: 'style--id',
@@ -66,7 +66,7 @@ export const DocumentLayerConfigPanel = (props: Props) => {
           <DocumentLayerStyle {...newProps} />
         </Fragment>
       ),
-      testSubj: 'styleTab',
+      testsubj: 'styleTab',
     },
     {
       id: 'settings--id',
@@ -77,7 +77,7 @@ export const DocumentLayerConfigPanel = (props: Props) => {
           <LayerBasicSettings {...newProps} />
         </Fragment>
       ),
-      testSubj: 'settingsTab',
+      testsubj: 'settingsTab',
     },
   ];
   return <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} />;

--- a/public/components/layer_config/layer_config_panel.tsx
+++ b/public/components/layer_config/layer_config_panel.tsx
@@ -42,6 +42,7 @@ interface Props {
   isLayerExists: Function;
   originLayerConfig: MapLayerSpecification | null;
   setOriginLayerConfig: Function;
+  setIsUpdatingLayerRender: (isUpdatingLayerRender: boolean) => void;
 }
 
 export const LayerConfigPanel = ({
@@ -55,6 +56,7 @@ export const LayerConfigPanel = ({
   isLayerExists,
   originLayerConfig,
   setOriginLayerConfig,
+  setIsUpdatingLayerRender,
 }: Props) => {
   const [isUpdateDisabled, setIsUpdateDisabled] = useState(false);
   const [unsavedModalVisible, setUnsavedModalVisible] = useState(false);
@@ -84,9 +86,11 @@ export const LayerConfigPanel = ({
     }
   };
   const onUpdate = () => {
+    setIsUpdatingLayerRender(true);
     updateLayer();
     closeLayerConfigPanel(false);
     setOriginLayerConfig(null);
+    setSelectedLayerConfig(undefined);
     if (isNewLayer) {
       setIsNewLayer(false);
     }

--- a/public/components/map_page/map_page.tsx
+++ b/public/components/map_page/map_page.tsx
@@ -37,7 +37,7 @@ interface MapComponentProps {
   mapConfig: ConfigSchema;
   mapIdFromSavedObject: string;
   timeRange?: TimeRange;
-  inDashboardMode: boolean;
+  isReadOnlyMode: boolean;
   refreshConfig?: RefreshInterval;
   filters?: Filter[];
   query?: Query;
@@ -46,7 +46,7 @@ export const MapComponent = ({
   mapIdFromSavedObject,
   mapConfig,
   timeRange,
-  inDashboardMode,
+  isReadOnlyMode,
   refreshConfig,
   filters,
   query,
@@ -61,6 +61,7 @@ export const MapComponent = ({
   const [layersIndexPatterns, setLayersIndexPatterns] = useState<IndexPattern[]>([]);
   const maplibreRef = useRef<Maplibre | null>(null);
   const [mapState, setMapState] = useState<MapState>(getInitialMapState());
+  const [isUpdatingLayerRender, setIsUpdatingLayerRender] = useState(true);
 
   useEffect(() => {
     if (mapIdFromSavedObject) {
@@ -91,10 +92,10 @@ export const MapComponent = ({
 
   return (
     <div className="map-page">
-      {inDashboardMode ? null : (
+      {isReadOnlyMode ? null : (
         <MapTopNavMenu
           mapIdFromUrl={mapIdFromSavedObject}
-          inDashboardMode={inDashboardMode}
+          isReadOnlyMode={isReadOnlyMode}
           timeRange={timeRange}
           savedMapObject={savedMapObject}
           layers={layers}
@@ -102,6 +103,7 @@ export const MapComponent = ({
           maplibreRef={maplibreRef}
           mapState={mapState}
           setMapState={setMapState}
+          setIsUpdatingLayerRender={setIsUpdatingLayerRender}
         />
       )}
 
@@ -113,11 +115,13 @@ export const MapComponent = ({
         maplibreRef={maplibreRef}
         mapState={mapState}
         mapConfig={mapConfig}
-        inDashboardMode={inDashboardMode}
+        isReadOnlyMode={isReadOnlyMode}
         timeRange={timeRange}
         refreshConfig={refreshConfig}
         filters={filters}
         query={query}
+        isUpdatingLayerRender={isUpdatingLayerRender}
+        setIsUpdatingLayerRender={setIsUpdatingLayerRender}
       />
     </div>
   );
@@ -125,7 +129,5 @@ export const MapComponent = ({
 
 export const MapPage = ({ mapConfig }: MapPageProps) => {
   const { id: mapId } = useParams<{ id: string }>();
-  return (
-    <MapComponent mapIdFromSavedObject={mapId} mapConfig={mapConfig} inDashboardMode={false} />
-  );
+  return <MapComponent mapIdFromSavedObject={mapId} mapConfig={mapConfig} isReadOnlyMode={false} />;
 };

--- a/public/components/map_top_nav/top_nav_menu.tsx
+++ b/public/components/map_top_nav/top_nav_menu.tsx
@@ -24,21 +24,23 @@ interface MapTopNavMenuProps {
   maplibreRef: any;
   mapState: MapState;
   setMapState: (mapState: MapState) => void;
-  inDashboardMode: boolean;
+  isReadOnlyMode: boolean;
   timeRange?: TimeRange;
   originatingApp?: string;
+  setIsUpdatingLayerRender: (isUpdatingLayerRender: boolean) => void;
 }
 
 export const MapTopNavMenu = ({
   mapIdFromUrl,
   savedMapObject,
-  inDashboardMode,
+  isReadOnlyMode,
   timeRange,
   layers,
   layersIndexPatterns,
   maplibreRef,
   mapState,
   setMapState,
+  setIsUpdatingLayerRender,
 }: MapTopNavMenuProps) => {
   const { services } = useOpenSearchDashboards<MapServices>();
   const {
@@ -96,6 +98,7 @@ export const MapTopNavMenu = ({
   };
 
   const handleQuerySubmit = ({ query, dateRange }: { query?: Query; dateRange: TimeRange }) => {
+    setIsUpdatingLayerRender(true);
     if (query) {
       setMapState({ ...mapState, query });
     }
@@ -105,7 +108,7 @@ export const MapTopNavMenu = ({
   };
 
   useEffect(() => {
-    if (!inDashboardMode) {
+    if (!isReadOnlyMode) {
       setDateFrom(mapState.timeRange.from);
       setDateTo(mapState.timeRange.to);
     } else {
@@ -144,9 +147,9 @@ export const MapTopNavMenu = ({
       config={config}
       setMenuMountPoint={setHeaderActionMenu}
       indexPatterns={layersIndexPatterns || []}
-      showSearchBar={!inDashboardMode}
+      showSearchBar={!isReadOnlyMode}
       showFilterBar={false}
-      showDatePicker={!inDashboardMode}
+      showDatePicker={!isReadOnlyMode}
       showQueryBar={true}
       showSaveQuery={true}
       showQueryInput={true}

--- a/public/embeddable/map_component.tsx
+++ b/public/embeddable/map_component.tsx
@@ -41,7 +41,7 @@ export function MapEmbeddableComponentInner({ embeddable, input }: Props) {
         mapConfig={embeddable.getMapConfig()}
         mapIdFromSavedObject={input.savedObjectId}
         timeRange={timeRange}
-        inDashboardMode={true}
+        isReadOnlyMode={true}
         refreshConfig={refreshConfig}
         filters={filters}
         query={query}

--- a/public/model/layerRenderController.ts
+++ b/public/model/layerRenderController.ts
@@ -4,7 +4,7 @@
  */
 
 import { Map as Maplibre } from 'maplibre-gl';
-import { DocumentLayerSpecification, MapLayerSpecification } from './mapLayerType';
+import { MapLayerSpecification } from './mapLayerType';
 import { DASHBOARDS_MAPS_LAYER_TYPE } from '../../common';
 import {
   buildOpenSearchQuery,
@@ -92,7 +92,7 @@ export const prepareDataLayerSource = (
 };
 
 export const handleDataLayerRender = (
-  mapLayer: DocumentLayerSpecification,
+  mapLayer: MapLayerSpecification,
   mapState: MapState,
   services: MapServices,
   maplibreRef: MaplibreRef,
@@ -101,6 +101,9 @@ export const handleDataLayerRender = (
   filtersFromDashboard?: Filter[],
   query?: Query
 ) => {
+  if (mapLayer.type !== DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS) {
+    return;
+  }
   // filters are passed from dashboard filters and geo bounding box filters
   const filters: Filter[] = [];
   filters.push(...(filtersFromDashboard ? filtersFromDashboard : []));

--- a/public/model/layersFunctions.ts
+++ b/public/model/layersFunctions.ts
@@ -61,3 +61,24 @@ export const referenceLayerTypeLookup = {
   [DASHBOARDS_MAPS_LAYER_TYPE.CUSTOM_MAP]: true,
   [DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS]: false,
 };
+
+export const getDataLayers = (layers: MapLayerSpecification[]) => {
+  return layers.filter((layer) => !referenceLayerTypeLookup[layer.type]);
+};
+
+export const getReferenceLayers = (layers: MapLayerSpecification[]) => {
+  return layers.filter((layer) => referenceLayerTypeLookup[layer.type]);
+};
+
+// Get layer id from layers that is above the selected layer
+export const getMapBeforeLayerId = (
+  layers: MapLayerSpecification[],
+  selectedLayerId: string
+): string | undefined => {
+  const selectedLayerIndex = layers.findIndex((layer) => layer.id === selectedLayerId);
+  const beforeLayers = layers.slice(selectedLayerIndex + 1);
+  if (beforeLayers.length === 0) {
+    return undefined;
+  }
+  return beforeLayers[0]?.id;
+};


### PR DESCRIPTION
### Description
Move layer handlers from layerControlPanel component to it's parent mapContainer component. The refactoring also fixed the duplicate handler call when in viewOnlyMode(dashboard mode).


https://github.com/opensearch-project/dashboards-maps/issues/270


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
