### PR TITLE
Add indexPatterns to map embeddable output for dashboard filters

### DIFF
--- a/public/embeddable/map_embeddable.tsx
+++ b/public/embeddable/map_embeddable.tsx
@@ -16,7 +16,7 @@ import {
 import { MapEmbeddableComponent } from './map_component';
 import { ConfigSchema } from '../../common/config';
 import { MapSavedObjectAttributes } from '../../common/map_saved_object_attributes';
-import { RefreshInterval } from '../../../../src/plugins/data/public';
+import { IndexPattern, RefreshInterval } from '../../../../src/plugins/data/public';
 
 export const MAP_EMBEDDABLE = MAP_SAVED_OBJECT_TYPE;
 
@@ -25,15 +25,28 @@ export interface MapInput extends EmbeddableInput {
   refreshConfig?: RefreshInterval;
 }
 
-export type MapOutput = EmbeddableOutput;
+export interface MapOutput extends EmbeddableOutput {
+  editable: boolean;
+  editUrl: string;
+  defaultTitle: string;
+  editApp: string;
+  editPath: string;
+  indexPatterns: IndexPattern[];
+}
 
-function getOutput(input: MapInput, editUrl: string, tittle: string): MapOutput {
+function getOutput(
+  input: MapInput,
+  editUrl: string,
+  tittle: string,
+  indexPatterns: IndexPattern[]
+): MapOutput {
   return {
     editable: true,
     editUrl,
     defaultTitle: tittle,
     editApp: MAPS_APP_ID,
     editPath: input.savedObjectId,
+    indexPatterns,
   };
 }
 
@@ -51,19 +64,25 @@ export class MapEmbeddable extends Embeddable<MapInput, MapOutput> {
       mapConfig,
       editUrl,
       savedMapAttributes,
+      indexPatterns,
     }: {
       parent?: IContainer;
       services: any;
       mapConfig: ConfigSchema;
       editUrl: string;
       savedMapAttributes: MapSavedObjectAttributes;
+      indexPatterns: IndexPattern[];
     }
   ) {
-    super(initialInput, getOutput(initialInput, editUrl, savedMapAttributes.title), parent);
+    super(
+      initialInput,
+      getOutput(initialInput, editUrl, savedMapAttributes.title, indexPatterns),
+      parent
+    );
     this.mapConfig = mapConfig;
     this.services = services;
     this.subscription = this.getInput$().subscribe(() => {
-      this.updateOutput(getOutput(this.input, editUrl, savedMapAttributes.title));
+      this.updateOutput(getOutput(this.input, editUrl, savedMapAttributes.title, indexPatterns));
     });
   }
 


### PR DESCRIPTION
### Description
In dashboard global filter bar component, it need read indexPatterns information from maps embeddable output to correctly show the maps data layers indexPattern.

Consuming ref: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/dashboard/public/application/dashboard_app_controller.tsx#L292


<img width="723" alt="image" src="https://user-images.githubusercontent.com/90288540/220303272-d38c4500-da54-435c-871c-b14c53329f24.png">



### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/214

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
