### PR TITLE
Show scroll bar when panel height reaches container bottom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 target/
 build/
 coverage/
+cypress/videos/
+cypress/screenshots/
+yarn-error.log
+.DS_Store

--- a/public/components/layer_control_panel/layer_control_panel.scss
+++ b/public/components/layer_control_panel/layer_control_panel.scss
@@ -1,3 +1,5 @@
+@import "../../variables";
+
 .layerControlPanel--show {
   pointer-events: auto;
   width: $euiSizeL * 11;
@@ -26,7 +28,10 @@
   .euiDroppable {
     overflow-y: auto;
     overflow-x: hidden;
-    max-height: $euiSizeL * 8;
+  }
+
+  .euiFlexGroup--directionColumn {
+    max-height: calc(100vh - #{$mapHeaderOffset} - #{$euiSizeL});
   }
 }
 


### PR DESCRIPTION
### Description
Show scroll bar when layer control panel height reaches map container bottom.




https://user-images.githubusercontent.com/90288540/221646365-a98ed3fc-4592-4380-b3d1-4902425f594a.mov




### Issues Resolved
Closes #293

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
