### PR TITLE
Enhance layer visibility status display

### DIFF
--- a/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/public/components/layer_control_panel/layer_control_panel.tsx
@@ -227,7 +227,7 @@ export const LayerControlPanel = memo(
     };
 
     const getLayerTooltipContent = (layer: MapLayerSpecification) => {
-      if (layer.visibility === 'none') {
+      if (layer.visibility !== 'visible') {
         return i18n.translate('maps.layerControl.layerIsHidden', {
           defaultMessage: 'Layer is hidden',
         });
@@ -242,7 +242,7 @@ export const LayerControlPanel = memo(
     };
 
     const layerIsVisible = (layer: MapLayerSpecification): boolean => {
-      if (layer.visibility === 'none') {
+      if (layer.visibility !== 'visible') {
         return false;
       }
       return visibleLayers.includes(layer);

--- a/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/public/components/layer_control_panel/layer_control_panel.tsx
@@ -24,6 +24,7 @@ import { I18nProvider } from '@osd/i18n/react';
 import { Map as Maplibre } from 'maplibre-gl';
 import './layer_control_panel.scss';
 import { isEqual } from 'lodash';
+import { i18n } from '@osd/i18n';
 import { IndexPattern } from '../../../../../src/plugins/data/public';
 import { AddLayerPanel } from '../add_layer_panel';
 import { LayerConfigPanel } from '../layer_config';
@@ -227,11 +228,15 @@ export const LayerControlPanel = memo(
 
     const getLayerTooltipContent = (layer: MapLayerSpecification) => {
       if (layer.visibility === 'none') {
-        return 'Layer is hidden';
+        return i18n.translate('maps.layerControl.layerIsHidden', {
+          defaultMessage: 'Layer is hidden',
+        });
       }
 
       if (zoom < layer.zoomRange[0] || zoom > layer.zoomRange[1]) {
-        return `Layer is not visible outside of zoom range ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`;
+        return i18n.translate('maps.layerControl.layerNotVisibleZoom', {
+          defaultMessage: `Layer is not visible outside of zoom range ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`,
+        });
       }
       return '';
     };

--- a/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/public/components/layer_control_panel/layer_control_panel.tsx
@@ -226,14 +226,20 @@ export const LayerControlPanel = memo(
     };
 
     const getLayerTooltipContent = (layer: MapLayerSpecification) => {
+      if (layer.visibility === 'none') {
+        return 'Layer is hidden';
+      }
+
       if (zoom < layer.zoomRange[0] || zoom > layer.zoomRange[1]) {
         return `Layer is not visible outside of zoom range ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`;
-      } else {
-        return `Layer is visible within zoom range ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`;
       }
+      return '';
     };
 
-    const layerIsVisible = (layer: MapLayerSpecification) => {
+    const layerIsVisible = (layer: MapLayerSpecification): boolean => {
+      if (layer.visibility === 'none') {
+        return false;
+      }
       return visibleLayers.includes(layer);
     };
 
@@ -310,16 +316,11 @@ export const LayerControlPanel = memo(
                                 />
                               </EuiFlexItem>
                               <EuiFlexItem>
-                                <EuiToolTip
-                                  position="top"
-                                  title={layerIsVisible(layer) ? '' : layer.name}
-                                  content={
-                                    layerIsVisible(layer) ? '' : getLayerTooltipContent(layer)
-                                  }
-                                >
+                                <EuiToolTip position="top" content={getLayerTooltipContent(layer)}>
                                   <EuiListGroupItem
                                     key={layer.id}
                                     label={layer.name}
+                                    color={layerIsVisible(layer) ? 'text' : 'subdued'}
                                     aria-label="layer in the map layers list"
                                     onClick={() => onClickLayerName(layer)}
                                     showToolTip={false}

--- a/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/public/components/layer_control_panel/layer_control_panel.tsx
@@ -235,7 +235,7 @@ export const LayerControlPanel = memo(
 
       if (zoom < layer.zoomRange[0] || zoom > layer.zoomRange[1]) {
         return i18n.translate('maps.layerControl.layerNotVisibleZoom', {
-          defaultMessage: `Layer is not visible outside of zoom range ${layer.zoomRange[0]} - ${layer.zoomRange[1]}`,
+          defaultMessage: `Layer is hidden outside of zoom range ${layer.zoomRange[0]}–${layer.zoomRange[1]}`,
         });
       }
       return '';


### PR DESCRIPTION
### Description
Enhance layer visibility status display.

Priority 0: When layer visibility is none: 1) show tooltip "layer is hidden" and 2) gray out the icon and layer name

![image](https://user-images.githubusercontent.com/90288540/221714491-38451625-c593-4d56-aa4c-798567be3b6a.png)

Priority 1: When layer setting zoom level range is out of current zoom level, 1) show tooltip "layer is not visible outside of zoom range a to b" and 2) gray out the icon and layer name
![image](https://user-images.githubusercontent.com/90288540/221714532-86f29dce-8230-4cab-b03b-d7a0e4230a8c.png)


### Issues Resolved
Closes https://github.com/opensearch-project/dashboards-maps/issues/298

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
