### PR TITLE
Move zoom and coordinates as separate component

### DIFF
--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import { EuiPanel } from '@elastic/eui';
 import { LngLat, Map as Maplibre, NavigationControl, Popup, MapEventType } from 'maplibre-gl';
 import { debounce, throttle } from 'lodash';
 import { LayerControlPanel } from '../layer_control_panel';
@@ -34,6 +33,7 @@ import {
   getReferenceLayers,
   referenceLayerTypeLookup,
 } from '../../model/layersFunctions';
+import { MapsFooter } from './mapsFooter';
 
 interface MapContainerProps {
   setLayers: (layers: MapLayerSpecification[]) => void;
@@ -298,19 +298,7 @@ export const MapContainer = ({
 
   return (
     <div className="map-main">
-      <EuiPanel
-        hasShadow={false}
-        hasBorder={false}
-        color="transparent"
-        className="zoombar"
-        data-test-subj="mapStatusBar"
-      >
-        <small>
-          {coordinates &&
-            `lat: ${coordinates.lat.toFixed(4)}, lon: ${coordinates.lng.toFixed(4)}, `}
-          zoom: {zoom}
-        </small>
-      </EuiPanel>
+      <MapsFooter coordinates={coordinates} zoom={zoom} />
       {mounted && (
         <LayerControlPanel
           maplibreRef={maplibreRef}

--- a/public/components/map_container/mapsFooter.test.tsx
+++ b/public/components/map_container/mapsFooter.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+import { MapsFooter } from './mapsFooter';
+import { LngLat } from 'maplibre-gl';
+
+let container: Element | null;
+beforeEach(() => {
+  // setup a DOM element as a render target
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  // cleanup on exiting
+  unmountComponentAtNode(container!);
+  container?.remove();
+  container = null;
+});
+
+it('renders with or without coordinates', () => {
+  act(() => {
+    render(<MapsFooter zoom={3} />, container);
+  });
+  expect(container?.textContent).toBe('zoom: 3');
+
+  act(() => {
+    const coordinates: LngLat = new LngLat(-73.974912, 40.773654);
+    render(<MapsFooter zoom={3} coordinates={coordinates} />, container);
+  });
+  expect(container?.textContent).toBe('lat: 40.7737, lon: -73.9749, zoom: 3');
+});

--- a/public/components/map_container/mapsFooter.tsx
+++ b/public/components/map_container/mapsFooter.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiPanel } from '@elastic/eui';
+import { isEqual } from 'lodash';
+import React, { memo } from 'react';
+import { LngLat } from 'maplibre-gl';
+
+const coordinatesRoundOffDigit = 4;
+interface MapFooterProps {
+  coordinates?: LngLat;
+  zoom: number;
+}
+
+export const MapsFooter = memo(({ coordinates, zoom }: MapFooterProps) => {
+  return (
+    <EuiPanel
+      hasShadow={false}
+      hasBorder={false}
+      color="transparent"
+      className="zoombar"
+      data-test-subj="mapStatusBar"
+    >
+      <small>
+        {coordinates &&
+          `lat: ${coordinates.lat.toFixed(
+            coordinatesRoundOffDigit
+          )}, lon: ${coordinates.lng.toFixed(coordinatesRoundOffDigit)}, `}
+        zoom: {zoom}
+      </small>
+    </EuiPanel>
+  );
+}, isEqual);


### PR DESCRIPTION
### Description
Move zoom and coordinates as separate component.
We don't have to render zoom/coordiantes if there is no change in maps movement.

Added unit test to check render

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
