### PR TITLE
Introduce disable tooltip on hover property

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -31,6 +31,7 @@ export const DOCUMENTS_MIN_MARKER_BORDER_THICKNESS = 0;
 export const DOCUMENTS_MAX_MARKER_BORDER_THICKNESS = 100;
 export const DOCUMENTS_DEFAULT_REQUEST_NUMBER = 1000;
 export const DOCUMENTS_DEFAULT_SHOW_TOOLTIPS: boolean = false;
+export const DOCUMENTS_DEFAULT_DISABLE_TOOLTIPS_ON_HOVER: boolean = false;
 export const DOCUMENTS_DEFAULT_TOOLTIPS: string[] = [];
 export const LAYER_PANEL_HIDE_LAYER_ICON = 'eyeClosed';
 export const LAYER_PANEL_SHOW_LAYER_ICON = 'eye';

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -18,7 +18,12 @@ import {
   Query,
 } from '../../../../../src/plugins/data/public';
 import { MapState } from '../../model/mapState';
-import { createPopup, getPopupLocation, isTooltipEnabledLayer } from '../tooltip/create_tooltip';
+import {
+  createPopup,
+  getPopupLocation,
+  isTooltipEnabledLayer,
+  isTooltipEnabledOnHover,
+} from '../tooltip/create_tooltip';
 import {
   handleDataLayerRender,
   handleReferenceLayerRender,
@@ -153,11 +158,12 @@ export const MapContainer = ({
       // remove previous popup
       hoverPopup?.remove();
 
+      const tooltipEnabledLayersOnHover = layers.filter(isTooltipEnabledOnHover);
       const features = maplibreRef.current?.queryRenderedFeatures(e.point);
       if (features && maplibreRef.current) {
         hoverPopup = createPopup({
           features,
-          layers: tooltipEnabledLayers,
+          layers: tooltipEnabledLayersOnHover,
           // enable close button to avoid occasional dangling tooltip that is not cleared during mouse leave action
           showCloseButton: true,
           showPagination: false,

--- a/public/components/tooltip/create_tooltip.tsx
+++ b/public/components/tooltip/create_tooltip.tsx
@@ -25,6 +25,12 @@ export function isTooltipEnabledLayer(
   );
 }
 
+export function isTooltipEnabledOnHover(
+  layer: MapLayerSpecification
+): layer is DocumentLayerSpecification {
+  return isTooltipEnabledLayer(layer) && !layer.source?.disableTooltipsOnHover;
+}
+
 export function groupFeaturesByLayers(
   features: MapGeoJSONFeature[],
   layers: DocumentLayerSpecification[]

--- a/public/model/mapLayerType.ts
+++ b/public/model/mapLayerType.ts
@@ -42,6 +42,7 @@ export type DocumentLayerSpecification = {
     geoFieldName: string;
     documentRequestNumber: number;
     showTooltips: boolean;
+    disableTooltipsOnHover?: boolean;
     tooltipFields: string[];
     useGeoBoundingBoxFilter: boolean;
     filters: Filter[];

--- a/public/utils/getIntialConfig.ts
+++ b/public/utils/getIntialConfig.ts
@@ -18,6 +18,7 @@ import {
   MAP_REFERENCE_LAYER_DEFAULT_OPACITY,
   OPENSEARCH_MAP_LAYER,
   CUSTOM_MAP,
+  DOCUMENTS_DEFAULT_DISABLE_TOOLTIPS_ON_HOVER,
 } from '../../common';
 import { MapState } from '../model/mapState';
 import { ConfigSchema } from '../../common/config';
@@ -53,6 +54,7 @@ export const getLayerConfigMap = (mapConfig: ConfigSchema) => ({
       documentRequestNumber: DOCUMENTS_DEFAULT_REQUEST_NUMBER,
       tooltipFields: DOCUMENTS_DEFAULT_TOOLTIPS,
       showTooltips: DOCUMENTS_DEFAULT_SHOW_TOOLTIPS,
+      disableTooltipsOnHover: DOCUMENTS_DEFAULT_DISABLE_TOOLTIPS_ON_HOVER,
     },
     style: {
       ...getStyleColor(),


### PR DESCRIPTION
### Description
Added new property that allows users to disable tooltip on hover. The default value is false to keep
backward compatability. We will revisit the ideal
default value based on user's feedback in later release.

### Issues Resolved
#259 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
