### PR TITLE
Add tooltip to draw shape filter

### DIFF
--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -8,7 +8,12 @@ import { Map as Maplibre, NavigationControl } from 'maplibre-gl';
 import { debounce, throttle } from 'lodash';
 import { LayerControlPanel } from '../layer_control_panel';
 import './map_container.scss';
-import { DASHBOARDS_MAPS_LAYER_TYPE, DrawFilterProperties, FILTER_DRAW_MODE, MAP_INITIAL_STATE } from '../../../common';
+import {
+  DASHBOARDS_MAPS_LAYER_TYPE,
+  DrawFilterProperties,
+  FILTER_DRAW_MODE,
+  MAP_INITIAL_STATE,
+} from '../../../common';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import {
   Filter,
@@ -36,7 +41,7 @@ import { MapsFooter } from './maps_footer';
 import { DisplayFeatures } from '../tooltip/display_features';
 import { TOOLTIP_STATE } from '../../../common';
 import { SpatialFilterToolbar } from '../toolbar/spatial_filter/filter_toolbar';
-import {DrawTooltip} from "../toolbar/spatial_filter/draw_tooltip";
+import { DrawTooltip } from '../toolbar/spatial_filter/draw_tooltip';
 
 interface MapContainerProps {
   setLayers: (layers: MapLayerSpecification[]) => void;
@@ -266,7 +271,9 @@ export const MapContainer = ({
       {mounted && tooltipState === TOOLTIP_STATE.DISPLAY_FEATURES && (
         <DisplayFeatures map={maplibreRef.current!} layers={layers} />
       )}
-      {mounted && <DrawTooltip map={maplibreRef.current!} mode={filterProperties.mode} />}
+      {mounted && Boolean(maplibreRef.current) && (
+        <DrawTooltip map={maplibreRef.current!} mode={filterProperties.mode} />
+      )}
       <div className="SpatialFilterToolbar-container">
         {mounted && (
           <SpatialFilterToolbar

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -36,6 +36,7 @@ import { MapsFooter } from './maps_footer';
 import { DisplayFeatures } from '../tooltip/display_features';
 import { TOOLTIP_STATE } from '../../../common';
 import { SpatialFilterToolbar } from '../toolbar/spatial_filter/filter_toolbar';
+import {DrawTooltip} from "../toolbar/spatial_filter/draw_tooltip";
 
 interface MapContainerProps {
   setLayers: (layers: MapLayerSpecification[]) => void;
@@ -265,6 +266,7 @@ export const MapContainer = ({
       {mounted && tooltipState === TOOLTIP_STATE.DISPLAY_FEATURES && (
         <DisplayFeatures map={maplibreRef.current!} layers={layers} />
       )}
+      {mounted && <DrawTooltip map={maplibreRef.current!} mode={filterProperties.mode} />}
       <div className="SpatialFilterToolbar-container">
         {mounted && (
           <SpatialFilterToolbar

--- a/public/components/toolbar/spatial_filter/draw_tooltip.tsx
+++ b/public/components/toolbar/spatial_filter/draw_tooltip.tsx
@@ -13,7 +13,8 @@ interface Props {
   mode: FILTER_DRAW_MODE;
 }
 
-const gapBetweenCursorAndPopupOnXAxis: number = -12;
+const X_AXIS_GAP_BETWEEN_CURSOR_AND_POPUP = -12;
+const Y_AXIS_GAP_BETWEEN_CURSOR_AND_POPUP = 0;
 
 const getTooltipContent = (mode: FILTER_DRAW_MODE): string => {
   switch (mode) {
@@ -42,34 +43,36 @@ export const DrawTooltip = ({ map, mode }: Props) => {
     // remove previous popup
     function onMouseMoveMap(e: MapEventType['mousemove']) {
       map.getCanvas().style.cursor = 'crosshair'; // Changes cursor to '+'
-      if (map) {
-        hoverPopupRef.current
-          .setLngLat(e.lngLat)
-          .setOffset([gapBetweenCursorAndPopupOnXAxis, 0]) // add some gap between cursor and pop up
-          .setText(getTooltipContent(mode))
-          .addTo(map);
-      }
+      hoverPopupRef.current
+        .setLngLat(e.lngLat)
+        .setOffset([X_AXIS_GAP_BETWEEN_CURSOR_AND_POPUP, Y_AXIS_GAP_BETWEEN_CURSOR_AND_POPUP]) // add some gap between cursor and pop up
+        .setText(getTooltipContent(mode))
+        .addTo(map);
     }
 
-    map.on('mouseout', (ev) => {
+    function onMouseMoveOut() {
       hoverPopupRef.current.remove();
-    });
+    }
 
-    if (map && mode === FILTER_DRAW_MODE.NONE) {
+    function resetAction() {
       map.getCanvas().style.cursor = '';
-      hoverPopupRef?.current.remove();
+      hoverPopupRef.current.remove();
       // remove tooltip when users mouse move over a point
       map.off('mousemove', onMouseMoveMap);
+      map.off('mouseout', onMouseMoveOut);
+    }
+
+    if (map && mode === FILTER_DRAW_MODE.NONE) {
+      resetAction();
     } else {
       // add tooltip when users mouse move over a point
       map.on('mousemove', onMouseMoveMap);
+      map.on('mouseout', onMouseMoveOut);
     }
     return () => {
-      if (map) {
-        // remove tooltip when users mouse move over a point
-        // when component is unmounted
-        map.off('mousemove', onMouseMoveMap);
-      }
+      // remove tooltip when users mouse move over a point
+      // when component is unmounted
+      resetAction();
     };
   }, [mode]);
 

--- a/public/components/toolbar/spatial_filter/draw_tooltip.tsx
+++ b/public/components/toolbar/spatial_filter/draw_tooltip.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import maplibregl, { Map as Maplibre, MapEventType, Popup } from 'maplibre-gl';
+import React, { Fragment, useEffect, useRef } from 'react';
+import { i18n } from '@osd/i18n';
+import { FILTER_DRAW_MODE } from '../../../../common';
+
+interface Props {
+  map: Maplibre;
+  mode: FILTER_DRAW_MODE;
+}
+
+const gapBetweenCursorAndPopupOnXAxis: number = -12;
+
+const getTooltipContent = (mode: FILTER_DRAW_MODE): string => {
+  switch (mode) {
+    case FILTER_DRAW_MODE.POLYGON:
+      return i18n.translate('maps.drawFilterPolygon.tooltipContent', {
+        defaultMessage: 'Click to start shape. Click for vertex. Double click to finish.',
+      });
+    default:
+      return i18n.translate('maps.drawFilterDefault.tooltipContent', {
+        defaultMessage: 'Click to start shape. Double click to finish.',
+      });
+  }
+};
+
+export const DrawTooltip = ({ map, mode }: Props) => {
+  const hoverPopupRef = useRef<Popup>(
+    new maplibregl.Popup({
+      closeButton: false,
+      closeOnClick: false,
+      anchor: 'right',
+      maxWidth: 'max-content',
+    })
+  );
+
+  useEffect(() => {
+    // remove previous popup
+    function onMouseMoveMap(e: MapEventType['mousemove']) {
+      map.getCanvas().style.cursor = 'crosshair'; // Changes cursor to '+'
+      if (map) {
+        hoverPopupRef.current
+          .setLngLat(e.lngLat)
+          .setOffset([gapBetweenCursorAndPopupOnXAxis, 0]) // add some gap between cursor and pop up
+          .setText(getTooltipContent(mode))
+          .addTo(map);
+      }
+    }
+
+    map.on('mouseout', (ev) => {
+      hoverPopupRef.current.remove();
+    });
+
+    if (map && mode === FILTER_DRAW_MODE.NONE) {
+      map.getCanvas().style.cursor = '';
+      hoverPopupRef?.current.remove();
+      // remove tooltip when users mouse move over a point
+      map.off('mousemove', onMouseMoveMap);
+    } else {
+      // add tooltip when users mouse move over a point
+      map.on('mousemove', onMouseMoveMap);
+    }
+    return () => {
+      if (map) {
+        // remove tooltip when users mouse move over a point
+        // when component is unmounted
+        map.off('mousemove', onMouseMoveMap);
+      }
+    };
+  }, [mode]);
+
+  return <Fragment />;
+};

--- a/public/components/toolbar/spatial_filter/filter_input_panel.tsx
+++ b/public/components/toolbar/spatial_filter/filter_input_panel.tsx
@@ -53,7 +53,7 @@ export const FilterInputPanel = ({
   };
 
   return (
-    <EuiPanel className={"spatialFilterGroup__popoverPanel"}>
+    <EuiPanel className={'spatialFilterGroup__popoverPanel'}>
       <EuiForm>
         <EuiFormRow label="Filter label" display="rowCompressed">
           <EuiFieldText


### PR DESCRIPTION
### Description
Add tooltip with instruction how to draw filter on map. This will not allow user to draw. It just provides
instructions on how to draw filter based on selection.

### Issues Resolved
#213 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).



https://user-images.githubusercontent.com/11067894/223634193-472dfb51-fcdf-48aa-baad-f202f538fcaa.mov


