### PR TITLE
BWC for label textType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introduce disable tooltip on hover property ([#313](https://github.com/opensearch-project/dashboards-maps/pull/313))
 * Update tooltip behavior change ([#317](https://github.com/opensearch-project/dashboards-maps/pull/317))
 * Update max supported layer count ([#332](https://github.com/opensearch-project/dashboards-maps/pull/332))
+* BWC for document layer label textType ([#340](https://github.com/opensearch-project/dashboards-maps/pull/340))
 ### Bug Fixes
 * Fix property value undefined check ([#276](https://github.com/opensearch-project/dashboards-maps/pull/276))
 * Show scroll bar when panel height reaches container bottom ([#295](https://github.com/opensearch-project/dashboards-maps/pull/295))

--- a/public/components/layer_config/documents_config/style/label_config.tsx
+++ b/public/components/layer_config/documents_config/style/label_config.tsx
@@ -151,7 +151,19 @@ export const LabelConfig = ({
   };
 
   const onChangeLabelFieldText = (options: EuiComboBoxOptionOption[]) => {
-    onChangeLabel('textByField', options[0]?.label || '');
+    const newSelectedLayerConfig = {
+      ...selectedLayerConfig,
+      style: {
+        ...selectedLayerConfig.style,
+        label: {
+          ...selectedLayerConfig.style?.label,
+          textByField: options[0]?.label || '',
+          // For backwards compatibility, set textType to BY_FIELD if textByField is set
+          textType: DOCUMENTS_LABEL_TEXT_TYPE.BY_FIELD,
+        },
+      },
+    };
+    setSelectedLayerConfig(newSelectedLayerConfig);
   };
 
   const label = selectedLayerConfig.style?.label;

--- a/public/model/documentLayerFunctions.ts
+++ b/public/model/documentLayerFunctions.ts
@@ -233,11 +233,7 @@ const updateLayer = (
 };
 
 // The function to render label for document layer
-const renderLabelLayer = (
-  layerConfig: DocumentLayerSpecification,
-  maplibreRef: MaplibreRef,
-  beforeLayerId: string | undefined
-) => {
+const renderLabelLayer = (layerConfig: DocumentLayerSpecification, maplibreRef: MaplibreRef) => {
   const hasLabelLayer = hasSymbolLayer(maplibreRef.current!, layerConfig.id);
   // If the label set to enabled, add the label layer
   if (layerConfig.style?.label?.enabled) {
@@ -245,7 +241,7 @@ const renderLabelLayer = (
     if (hasLabelLayer) {
       updateSymbolLayer(maplibreRef.current!, symbolLayerSpec);
     } else {
-      addSymbolLayer(maplibreRef.current!, symbolLayerSpec, beforeLayerId);
+      addSymbolLayer(maplibreRef.current!, symbolLayerSpec);
     }
   } else {
     // If the label set to disabled, remove the label layer if it exists
@@ -277,6 +273,6 @@ export const DocumentLayerFunctions = {
     beforeLayerId: string | undefined
   ) => {
     renderMarkerLayer(maplibreRef, layerConfig, data, beforeLayerId);
-    renderLabelLayer(layerConfig, maplibreRef, beforeLayerId);
+    renderLabelLayer(layerConfig, maplibreRef);
   },
 };

--- a/public/model/map/layer_operations.ts
+++ b/public/model/map/layer_operations.ts
@@ -271,20 +271,13 @@ export const removeSymbolLayer = (map: Maplibre, layerId: string) => {
   map.removeLayer(layerId + '-symbol');
 };
 
-export const addSymbolLayer = (
-  map: Maplibre,
-  specification: SymbolLayerSpecification,
-  beforeId?: string
-): string => {
+export const addSymbolLayer = (map: Maplibre, specification: SymbolLayerSpecification): string => {
   const symbolLayerId = specification.sourceId + '-symbol';
-  map.addLayer(
-    {
-      id: symbolLayerId,
-      type: 'symbol',
-      source: specification.sourceId,
-    },
-    beforeId
-  );
+  map.addLayer({
+    id: symbolLayerId,
+    type: 'symbol',
+    source: specification.sourceId,
+  });
   return updateSymbolLayer(map, specification);
 };
 


### PR DESCRIPTION
### Description
* For backwards compatibility, set textType to BY_FIELD if textByField is set
* Remove unused beforeLayerId for label layer

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/321

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
