### PR TITLE
Add mapbox-gl draw mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update tooltip behavior change ([#317](https://github.com/opensearch-project/dashboards-maps/pull/317))
 * Update max supported layer count ([#332](https://github.com/opensearch-project/dashboards-maps/pull/332))
 * BWC for document layer label textType ([#340](https://github.com/opensearch-project/dashboards-maps/pull/340))
+* Add mapbox-gl draw mode ([#347](https://github.com/opensearch-project/dashboards-maps/pull/347))
 
 ### Bug Fixes
 * Fix property value undefined check ([#276](https://github.com/opensearch-project/dashboards-maps/pull/276))

--- a/common/index.ts
+++ b/common/index.ts
@@ -165,4 +165,4 @@ export interface DrawFilterProperties {
 export const DRAW_FILTER_SHAPE_TITLE = 'DRAW SHAPE';
 export const DRAW_FILTER_POLYGON_DEFAULT_LABEL = 'polygon';
 export const DRAW_FILTER_POLYGON = 'Draw Polygon';
-export const DRAW_FILTER_POLYGON_RELATIONS = ['intersects', 'disjoint', 'within'];
+export const DRAW_FILTER_SPATIAL_RELATIONS = ['intersects', 'disjoint', 'within'];

--- a/common/index.ts
+++ b/common/index.ts
@@ -156,6 +156,13 @@ export enum FILTER_DRAW_MODE {
   POLYGON = 'polygon', // Filter is active and set to draw polygon
 }
 
+export const MAPBOX_GL_DRAW_CREATE_LISTENER = 'draw.create';
+
+export enum MAPBOX_GL_DRAW_MODES {
+  DRAW_POLYGON = 'draw_polygon',
+  SIMPLE_SELECT = 'simple_select',
+}
+
 export interface DrawFilterProperties {
   relation?: string;
   mode: FILTER_DRAW_MODE;

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -10,6 +10,7 @@ import { LayerControlPanel } from '../layer_control_panel';
 import './map_container.scss';
 import { DrawFilterProperties, FILTER_DRAW_MODE, MAP_INITIAL_STATE } from '../../../common';
 import { MapLayerSpecification } from '../../model/mapLayerType';
+import { DrawFilterShape } from '../toolbar/spatial_filter/draw_filter_shape';
 import {
   Filter,
   IndexPattern,
@@ -231,6 +232,13 @@ export const MapContainer = ({
       )}
       {mounted && Boolean(maplibreRef.current) && (
         <DrawTooltip map={maplibreRef.current!} mode={filterProperties.mode} />
+      )}
+      {mounted && maplibreRef.current && tooltipState === TOOLTIP_STATE.FILTER_DRAW_SHAPE && (
+        <DrawFilterShape
+          map={maplibreRef.current}
+          filterProperties={filterProperties}
+          updateFilterProperties={setFilterProperties}
+        />
       )}
       <div className="SpatialFilterToolbar-container">
         {mounted && (

--- a/public/components/toolbar/spatial_filter/draw_filter_shape.tsx
+++ b/public/components/toolbar/spatial_filter/draw_filter_shape.tsx
@@ -7,13 +7,19 @@ import React, { Fragment, useEffect, useRef } from 'react';
 import { IControl, Map as Maplibre } from 'maplibre-gl';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import { Feature } from 'geojson';
-import { DrawFilterProperties, FILTER_DRAW_MODE} from '../../../../common';
+import {
+  DrawFilterProperties,
+  FILTER_DRAW_MODE,
+  MAPBOX_GL_DRAW_MODES,
+  MAPBOX_GL_DRAW_CREATE_LISTENER,
+} from '../../../../common';
 
 interface DrawFilterShapeProps {
   filterProperties: DrawFilterProperties;
   map: Maplibre;
   updateFilterProperties: (properties: DrawFilterProperties) => void;
 }
+
 export const DrawFilterShape = ({
   filterProperties,
   map,
@@ -32,12 +38,12 @@ export const DrawFilterShape = ({
 
   useEffect(() => {
     if (map) {
-      map.addControl((mapboxDrawRef.current as unknown) as IControl);
-      map.on('draw.create', onDraw);
+      map.addControl((mapboxDrawRef.current as unknown) as IControl, 'top-right');
+      map.on(MAPBOX_GL_DRAW_CREATE_LISTENER, onDraw);
     }
     return () => {
       if (map) {
-        map.off('draw.create', onDraw);
+        map.off(MAPBOX_GL_DRAW_CREATE_LISTENER, onDraw);
         // eslint-disable-next-line react-hooks/exhaustive-deps
         map.removeControl((mapboxDrawRef.current as unknown) as IControl);
       }
@@ -46,10 +52,10 @@ export const DrawFilterShape = ({
 
   useEffect(() => {
     if (filterProperties.mode === FILTER_DRAW_MODE.POLYGON) {
-      mapboxDrawRef.current.changeMode('draw_polygon');
+      mapboxDrawRef.current.changeMode(MAPBOX_GL_DRAW_MODES.DRAW_POLYGON);
     } else {
       // default mode
-      mapboxDrawRef.current.changeMode('simple_select');
+      mapboxDrawRef.current.changeMode(MAPBOX_GL_DRAW_MODES.SIMPLE_SELECT);
     }
   }, [filterProperties.mode]);
 

--- a/public/components/toolbar/spatial_filter/draw_filter_shape.tsx
+++ b/public/components/toolbar/spatial_filter/draw_filter_shape.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { Fragment, useEffect, useRef } from 'react';
+import { IControl, Map as Maplibre } from 'maplibre-gl';
+import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { Feature } from 'geojson';
+import { DrawFilterProperties, FILTER_DRAW_MODE} from '../../../../common';
+
+interface DrawFilterShapeProps {
+  filterProperties: DrawFilterProperties;
+  map: Maplibre;
+  updateFilterProperties: (properties: DrawFilterProperties) => void;
+}
+export const DrawFilterShape = ({
+  filterProperties,
+  map,
+  updateFilterProperties,
+}: DrawFilterShapeProps) => {
+  const onDraw = (event: { features: Feature[] }) => {
+    updateFilterProperties({
+      mode: FILTER_DRAW_MODE.NONE,
+    });
+  };
+  const mapboxDrawRef = useRef<MapboxDraw>(
+    new MapboxDraw({
+      displayControlsDefault: false,
+    })
+  );
+
+  useEffect(() => {
+    if (map) {
+      map.addControl((mapboxDrawRef.current as unknown) as IControl);
+      map.on('draw.create', onDraw);
+    }
+    return () => {
+      if (map) {
+        map.off('draw.create', onDraw);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        map.removeControl((mapboxDrawRef.current as unknown) as IControl);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (filterProperties.mode === FILTER_DRAW_MODE.POLYGON) {
+      mapboxDrawRef.current.changeMode('draw_polygon');
+    } else {
+      // default mode
+      mapboxDrawRef.current.changeMode('simple_select');
+    }
+  }, [filterProperties.mode]);
+
+  return <Fragment />;
+};

--- a/public/components/toolbar/spatial_filter/filter_by_polygon.tsx
+++ b/public/components/toolbar/spatial_filter/filter_by_polygon.tsx
@@ -11,7 +11,7 @@ import {
   DrawFilterProperties,
   DRAW_FILTER_POLYGON,
   DRAW_FILTER_POLYGON_DEFAULT_LABEL,
-  DRAW_FILTER_POLYGON_RELATIONS,
+  DRAW_FILTER_SPATIAL_RELATIONS,
   DRAW_FILTER_SHAPE_TITLE,
 } from '../../../../common';
 import { FILTER_DRAW_MODE } from '../../../../common';
@@ -52,7 +52,7 @@ export const FilterByPolygon = ({
         <FilterInputPanel
           drawLabel={DRAW_FILTER_POLYGON}
           defaultFilterLabel={DRAW_FILTER_POLYGON_DEFAULT_LABEL}
-          relations={DRAW_FILTER_POLYGON_RELATIONS}
+          relations={DRAW_FILTER_SPATIAL_RELATIONS}
           onSubmit={onSubmit}
           mode={FILTER_DRAW_MODE.POLYGON}
         />


### PR DESCRIPTION
### Description
if tooltip state is draw , mount mapbox-gl-draw and change mode accordingly.
Added callback once draw is completed. Currently, callback will reset the draw mode. In future PR, will
add Filter Meta based on draw shape.

### Issues Resolved
#213 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).



https://user-images.githubusercontent.com/11067894/225174933-0cb198ba-bd62-40fb-9c63-5063da957786.mov


