### PR TITLE
Avoid trigger tooltip from label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update max supported layer count ([#332](https://github.com/opensearch-project/dashboards-maps/pull/332))
 * BWC for document layer label textType ([#340](https://github.com/opensearch-project/dashboards-maps/pull/340))
 * Add mapbox-gl draw mode ([#347](https://github.com/opensearch-project/dashboards-maps/pull/347))
+* Avoid trigger tooltip from label ([#350](https://github.com/opensearch-project/dashboards-maps/pull/350))
 
 ### Bug Fixes
 * Fix property value undefined check ([#276](https://github.com/opensearch-project/dashboards-maps/pull/276))

--- a/public/components/tooltip/display_features.tsx
+++ b/public/components/tooltip/display_features.tsx
@@ -32,6 +32,10 @@ export const DisplayFeatures = memo(({ map, layers }: Props) => {
 
       const features = map.queryRenderedFeatures(e.point);
       if (features && map) {
+        // don't show tooltip from labels
+        if (features.length === 1 && features[0].layer?.type === 'symbol') {
+          return;
+        }
         clickPopup = createPopup({ features, layers: tooltipEnabledLayers });
         clickPopup?.setLngLat(getPopupLocation(features[0].geometry, e.lngLat)).addTo(map);
       }
@@ -44,6 +48,10 @@ export const DisplayFeatures = memo(({ map, layers }: Props) => {
       const tooltipEnabledLayersOnHover = layers.filter(isTooltipEnabledOnHover);
       const features = map.queryRenderedFeatures(e.point);
       if (features && map) {
+        // don't show tooltip from labels
+        if (features.length === 1 && features[0].layer?.type === 'symbol') {
+          return;
+        }
         hoverPopup = createPopup({
           features,
           layers: tooltipEnabledLayersOnHover,


### PR DESCRIPTION
### Description
Avoid trigger tooltip from documents label


https://user-images.githubusercontent.com/90288540/225739081-669f1717-fdf6-41da-8955-08c878a73a7a.mov



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
