### PR TITLE
Sync maplibre layer order after layers rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix color picker component issue ([#305](https://github.com/opensearch-project/dashboards-maps/pull/305))
 * fix: layer filter setting been reset unexpectedly ([#327](https://github.com/opensearch-project/dashboards-maps/pull/327))
 * Fix data query in dashboard mode when enable around map filter ([#339](https://github.com/opensearch-project/dashboards-maps/pull/339))
+* Sync maplibre layer order after layers rendered ([#353](https://github.com/opensearch-project/dashboards-maps/pull/353))
 
 ### Infrastructure
 * Add CHANGELOG ([#342](https://github.com/opensearch-project/dashboards-maps/pull/342))

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -24,6 +24,7 @@ import {
   renderBaseLayers,
   handleDataLayerRender,
   handleBaseLayerRender,
+  orderLayers,
 } from '../../model/layerRenderController';
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { ResizeChecker } from '../../../../../src/plugins/opensearch_dashboards_utils/public';
@@ -168,17 +169,27 @@ export const MapContainer = ({
     if (isUpdatingLayerRender || isReadOnlyMode) {
       if (selectedLayerConfig) {
         if (baseLayerTypeLookup[selectedLayerConfig.type]) {
-          handleBaseLayerRender(selectedLayerConfig, maplibreRef, undefined);
+          handleBaseLayerRender(selectedLayerConfig, maplibreRef);
         } else {
           updateIndexPatterns();
-          handleDataLayerRender(selectedLayerConfig, mapState, services, maplibreRef, undefined);
+          handleDataLayerRender(selectedLayerConfig, mapState, services, maplibreRef);
         }
       } else {
         renderDataLayers(layers, mapState, services, maplibreRef, timeRange, filters, query);
         renderBaseLayers(layers, maplibreRef);
+        // Because of async layer rendering, layers order is not guaranteed, so we need to order layers
+        // after all layers are rendered.
+        maplibreRef.current!.once('idle', () => {
+          orderLayers(layers, maplibreRef.current!);
+        });
       }
       setIsUpdatingLayerRender(false);
     }
+    return () => {
+      maplibreRef.current!.off('idle', () => {
+        orderLayers(layers, maplibreRef.current!);
+      });
+    };
   }, [layers, mounted, timeRange, filters, query, mapState, isReadOnlyMode]);
 
   useEffect(() => {

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -166,6 +166,8 @@ export const MapContainer = ({
       return;
     }
 
+    const orderLayersAfterRenderLoaded = () => orderLayers(layers, maplibreRef.current!);
+
     if (isUpdatingLayerRender || isReadOnlyMode) {
       if (selectedLayerConfig) {
         if (baseLayerTypeLookup[selectedLayerConfig.type]) {
@@ -179,16 +181,12 @@ export const MapContainer = ({
         renderBaseLayers(layers, maplibreRef);
         // Because of async layer rendering, layers order is not guaranteed, so we need to order layers
         // after all layers are rendered.
-        maplibreRef.current!.once('idle', () => {
-          orderLayers(layers, maplibreRef.current!);
-        });
+        maplibreRef.current!.once('idle', orderLayersAfterRenderLoaded);
       }
       setIsUpdatingLayerRender(false);
     }
     return () => {
-      maplibreRef.current!.off('idle', () => {
-        orderLayers(layers, maplibreRef.current!);
-      });
+      maplibreRef.current!.off('idle', orderLayersAfterRenderLoaded);
     };
   }, [layers, mounted, timeRange, filters, query, mapState, isReadOnlyMode]);
 

--- a/public/components/map_top_nav/top_nav_menu.tsx
+++ b/public/components/map_top_nav/top_nav_menu.tsx
@@ -92,7 +92,7 @@ export const MapTopNavMenu = ({
   const refreshDataLayerRender = () => {
     layers.forEach((layer: MapLayerSpecification) => {
       if (layer.type === DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS) {
-        handleDataLayerRender(layer, mapState, services, maplibreRef, undefined);
+        handleDataLayerRender(layer, mapState, services, maplibreRef);
       }
     });
   };

--- a/public/model/OSMLayerFunctions.ts
+++ b/public/model/OSMLayerFunctions.ts
@@ -1,6 +1,5 @@
 import { Map as Maplibre, LayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
 import { OSMLayerSpecification } from './mapLayerType';
-import { getMaplibreBeforeLayerId } from './layersFunctions';
 import { getLayers, hasLayer } from './map/layer_operations';
 import { getMapLanguage } from '../../common/util';
 
@@ -53,11 +52,7 @@ const setLanguage = (maplibreRef: MaplibreRef, styleLayer: LayerSpecification) =
   }
 };
 
-const addNewLayer = (
-  layerConfig: OSMLayerSpecification,
-  maplibreRef: MaplibreRef,
-  beforeLayerId: string | undefined
-) => {
+const addNewLayer = (layerConfig: OSMLayerSpecification, maplibreRef: MaplibreRef) => {
   if (maplibreRef.current) {
     const { source, style } = layerConfig;
     maplibreRef.current.addSource(layerConfig.id, {
@@ -65,14 +60,13 @@ const addNewLayer = (
       url: source?.dataURL,
     });
     fetchStyleLayers(style?.styleURL).then((styleLayers: LayerSpecification[]) => {
-      const beforeMbLayerId = getMaplibreBeforeLayerId(layerConfig, maplibreRef, beforeLayerId);
       styleLayers.forEach((styleLayer) => {
         styleLayer.id = styleLayer.id + '_' + layerConfig.id;
         // TODO: Add comments on why we skip background type
         if (styleLayer.type !== 'background') {
           styleLayer.source = layerConfig.id;
         }
-        maplibreRef.current?.addLayer(styleLayer, beforeMbLayerId);
+        maplibreRef.current?.addLayer(styleLayer);
         setLanguage(maplibreRef, styleLayer);
         maplibreRef.current?.setLayoutProperty(styleLayer.id, 'visibility', layerConfig.visibility);
         maplibreRef.current?.setLayerZoomRange(
@@ -96,15 +90,11 @@ const addNewLayer = (
 
 // Functions for OpenSearch maps vector tile layer
 export const OSMLayerFunctions = {
-  render: (
-    maplibreRef: MaplibreRef,
-    layerConfig: OSMLayerSpecification,
-    beforeLayerId: string | undefined
-  ) => {
+  render: (maplibreRef: MaplibreRef, layerConfig: OSMLayerSpecification) => {
     // If layer already exist in maplibre source, update layer config
     // else add new layer.
     return hasLayer(maplibreRef.current!, layerConfig.id)
       ? updateLayerConfig(layerConfig, maplibreRef)
-      : addNewLayer(layerConfig, maplibreRef, beforeLayerId);
+      : addNewLayer(layerConfig, maplibreRef);
   },
 };

--- a/public/model/customLayerFunctions.ts
+++ b/public/model/customLayerFunctions.ts
@@ -1,6 +1,5 @@
 import { Map as Maplibre, AttributionControl, RasterSourceSpecification } from 'maplibre-gl';
 import { CustomLayerSpecification, OSMLayerSpecification } from './mapLayerType';
-import { getMaplibreBeforeLayerId } from './layersFunctions';
 import { hasLayer, removeLayers } from './map/layer_operations';
 
 interface MaplibreRef {
@@ -44,11 +43,7 @@ const updateLayerConfig = (layerConfig: CustomLayerSpecification, maplibreRef: M
   }
 };
 
-const addNewLayer = (
-  layerConfig: CustomLayerSpecification,
-  maplibreRef: MaplibreRef,
-  beforeLayerId: string | undefined
-) => {
+const addNewLayer = (layerConfig: CustomLayerSpecification, maplibreRef: MaplibreRef) => {
   const maplibreInstance = maplibreRef.current;
   if (maplibreInstance) {
     const tilesURL = getCustomMapURL(layerConfig);
@@ -59,23 +54,19 @@ const addNewLayer = (
       tileSize: 256,
       attribution: layerSource?.attribution,
     });
-    const beforeMbLayerId = getMaplibreBeforeLayerId(layerConfig, maplibreRef, beforeLayerId);
-    maplibreInstance.addLayer(
-      {
-        id: layerConfig.id,
-        type: 'raster',
-        source: layerConfig.id,
-        paint: {
-          'raster-opacity': layerConfig.opacity / 100,
-        },
-        layout: {
-          visibility: layerConfig.visibility === 'visible' ? 'visible' : 'none',
-        },
-        minzoom: layerConfig.zoomRange[0],
-        maxzoom: layerConfig.zoomRange[1],
+    maplibreInstance.addLayer({
+      id: layerConfig.id,
+      type: 'raster',
+      source: layerConfig.id,
+      paint: {
+        'raster-opacity': layerConfig.opacity / 100,
       },
-      beforeMbLayerId
-    );
+      layout: {
+        visibility: layerConfig.visibility === 'visible' ? 'visible' : 'none',
+      },
+      minzoom: layerConfig.zoomRange[0],
+      maxzoom: layerConfig.zoomRange[1],
+    });
   }
 };
 
@@ -92,14 +83,10 @@ const getCustomMapURL = (layerConfig: CustomLayerSpecification) => {
 };
 
 export const CustomLayerFunctions = {
-  render: (
-    maplibreRef: MaplibreRef,
-    layerConfig: CustomLayerSpecification,
-    beforeLayerId: string | undefined
-  ) => {
+  render: (maplibreRef: MaplibreRef, layerConfig: CustomLayerSpecification) => {
     return hasLayer(maplibreRef.current!, layerConfig.id)
       ? updateLayerConfig(layerConfig, maplibreRef)
-      : addNewLayer(layerConfig, maplibreRef, beforeLayerId);
+      : addNewLayer(layerConfig, maplibreRef);
   },
   remove: (maplibreRef: MaplibreRef, layerConfig: OSMLayerSpecification) => {
     removeLayers(maplibreRef.current!, layerConfig.id, true);

--- a/public/model/documentLayerFunctions.ts
+++ b/public/model/documentLayerFunctions.ts
@@ -7,7 +7,6 @@ import { Map as Maplibre } from 'maplibre-gl';
 import { parse } from 'wellknown';
 import { DocumentLayerSpecification } from './mapLayerType';
 import { convertGeoPointToGeoJSON, isGeoJSON } from '../utils/geo_formater';
-import { getMaplibreBeforeLayerId } from './layersFunctions';
 import {
   addCircleLayer,
   addLineLayer,
@@ -131,56 +130,43 @@ const addNewLayer = (
   if (!maplibreInstance) {
     return;
   }
-  const mbLayerBeforeId = getMaplibreBeforeLayerId(layerConfig, maplibreRef, beforeLayerId);
   const source = getLayerSource(data, layerConfig);
   maplibreInstance.addSource(layerConfig.id, {
     type: 'geojson',
     data: source,
   });
-  addCircleLayer(
-    maplibreInstance,
-    {
+  addCircleLayer(maplibreInstance, {
+    fillColor: layerConfig.style?.fillColor,
+    maxZoom: layerConfig.zoomRange[1],
+    minZoom: layerConfig.zoomRange[0],
+    opacity: layerConfig.opacity,
+    outlineColor: layerConfig.style?.borderColor,
+    radius: layerConfig.style?.markerSize,
+    sourceId: layerConfig.id,
+    visibility: layerConfig.visibility,
+    width: layerConfig.style?.borderThickness,
+  });
+  const geoFieldType = getGeoFieldType(layerConfig);
+  if (geoFieldType === 'geo_shape') {
+    addLineLayer(maplibreInstance, {
+      width: layerConfig.style?.borderThickness,
+      color: layerConfig.style?.fillColor,
+      maxZoom: layerConfig.zoomRange[1],
+      minZoom: layerConfig.zoomRange[0],
+      opacity: layerConfig.opacity,
+      sourceId: layerConfig.id,
+      visibility: layerConfig.visibility,
+    });
+    addPolygonLayer(maplibreInstance, {
+      width: layerConfig.style?.borderThickness,
       fillColor: layerConfig.style?.fillColor,
       maxZoom: layerConfig.zoomRange[1],
       minZoom: layerConfig.zoomRange[0],
       opacity: layerConfig.opacity,
-      outlineColor: layerConfig.style?.borderColor,
-      radius: layerConfig.style?.markerSize,
       sourceId: layerConfig.id,
+      outlineColor: layerConfig.style?.borderColor,
       visibility: layerConfig.visibility,
-      width: layerConfig.style?.borderThickness,
-    },
-    mbLayerBeforeId
-  );
-  const geoFieldType = getGeoFieldType(layerConfig);
-  if (geoFieldType === 'geo_shape') {
-    addLineLayer(
-      maplibreInstance,
-      {
-        width: layerConfig.style?.borderThickness,
-        color: layerConfig.style?.fillColor,
-        maxZoom: layerConfig.zoomRange[1],
-        minZoom: layerConfig.zoomRange[0],
-        opacity: layerConfig.opacity,
-        sourceId: layerConfig.id,
-        visibility: layerConfig.visibility,
-      },
-      mbLayerBeforeId
-    );
-    addPolygonLayer(
-      maplibreInstance,
-      {
-        width: layerConfig.style?.borderThickness,
-        fillColor: layerConfig.style?.fillColor,
-        maxZoom: layerConfig.zoomRange[1],
-        minZoom: layerConfig.zoomRange[0],
-        opacity: layerConfig.opacity,
-        sourceId: layerConfig.id,
-        outlineColor: layerConfig.style?.borderColor,
-        visibility: layerConfig.visibility,
-      },
-      mbLayerBeforeId
-    );
+    });
   }
 };
 

--- a/public/model/layersFunctions.ts
+++ b/public/model/layersFunctions.ts
@@ -67,9 +67,7 @@ export const baseLayerTypeLookup = {
 };
 
 export const getDataLayers = (layers: MapLayerSpecification[]): DataLayerSpecification[] => {
-  return layers.filter(
-    (layer) => !baseLayerTypeLookup[layer.type]
-  ) as DataLayerSpecification[];
+  return layers.filter((layer) => !baseLayerTypeLookup[layer.type]) as DataLayerSpecification[];
 };
 
 export const getBaseLayers = (layers: MapLayerSpecification[]): BaseLayerSpecification[] => {

--- a/public/model/map/layer_operations.ts
+++ b/public/model/map/layer_operations.ts
@@ -71,21 +71,14 @@ export interface LineLayerSpecification extends Layer {
   width: number;
 }
 
-export const addLineLayer = (
-  map: Maplibre,
-  specification: LineLayerSpecification,
-  beforeId?: string
-): string => {
+export const addLineLayer = (map: Maplibre, specification: LineLayerSpecification): string => {
   const lineLayerId = specification.sourceId + '-line';
-  map.addLayer(
-    {
-      id: lineLayerId,
-      type: 'line',
-      source: specification.sourceId,
-      filter: ['==', '$type', 'LineString'],
-    },
-    beforeId
-  );
+  map.addLayer({
+    id: lineLayerId,
+    type: 'line',
+    source: specification.sourceId,
+    filter: ['==', '$type', 'LineString'],
+  });
   return updateLineLayer(map, specification, lineLayerId);
 };
 
@@ -111,21 +104,14 @@ export interface CircleLayerSpecification extends Layer {
   width: number;
 }
 
-export const addCircleLayer = (
-  map: Maplibre,
-  specification: CircleLayerSpecification,
-  beforeId?: string
-): string => {
+export const addCircleLayer = (map: Maplibre, specification: CircleLayerSpecification): string => {
   const circleLayerId = specification.sourceId + '-circle';
-  map.addLayer(
-    {
-      id: circleLayerId,
-      type: 'circle',
-      source: specification.sourceId,
-      filter: ['==', '$type', 'Point'],
-    },
-    beforeId
-  );
+  map.addLayer({
+    id: circleLayerId,
+    type: 'circle',
+    source: specification.sourceId,
+    filter: ['==', '$type', 'Point'],
+  });
   return updateCircleLayer(map, specification, circleLayerId);
 };
 
@@ -153,35 +139,25 @@ export interface PolygonLayerSpecification extends Layer {
   width: number;
 }
 
-export const addPolygonLayer = (
-  map: Maplibre,
-  specification: PolygonLayerSpecification,
-  beforeId?: string
-) => {
+export const addPolygonLayer = (map: Maplibre, specification: PolygonLayerSpecification) => {
   const fillLayerId = specification.sourceId + '-fill';
-  map.addLayer(
-    {
-      id: fillLayerId,
-      type: 'fill',
-      source: specification.sourceId,
-      filter: ['==', '$type', 'Polygon'],
-    },
-    beforeId
-  );
+  map.addLayer({
+    id: fillLayerId,
+    type: 'fill',
+    source: specification.sourceId,
+    filter: ['==', '$type', 'Polygon'],
+  });
   updatePolygonFillLayer(map, specification, fillLayerId);
 
   // Due to limitations on WebGL, fill can't render outlines with width wider than 1,
   // so we have to create another style layer with type=line to apply width.
   const outlineId = fillLayerId + '-outline';
-  map.addLayer(
-    {
-      id: outlineId,
-      type: 'line',
-      source: specification.sourceId,
-      filter: ['==', '$type', 'Polygon'],
-    },
-    beforeId
-  );
+  map.addLayer({
+    id: outlineId,
+    type: 'line',
+    source: specification.sourceId,
+    filter: ['==', '$type', 'Polygon'],
+  });
   updateLineLayer(
     map,
     {


### PR DESCRIPTION
### Description
Because of async layer rendering, when there are multiple layers, the layers order may change in maplibre, adding a ordering function right after all layers render finished to make sure the order is correct at display. 

Since we're adding the order function to make sure all layers order finally, we can remove beforeLayerId parameters when call `addLayer()` to prevent unnecessary performance waste.

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/352

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
