### PR TITLE
Remove cancel button on draw shape and use Escape to cancel draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add mapbox-gl draw mode ([#347](https://github.com/opensearch-project/dashboards-maps/pull/347))
 * Add support to draw rectangle shape to filter documents ([#348](https://github.com/opensearch-project/dashboards-maps/pull/348))
 * Avoid trigger tooltip from label ([#350](https://github.com/opensearch-project/dashboards-maps/pull/350))
+* Remove cancel button on draw shape and use Escape to cancel draw ([#359](https://github.com/opensearch-project/dashboards-maps/pull/359))
 
 ### Bug Fixes
 * Fix property value undefined check ([#276](https://github.com/opensearch-project/dashboards-maps/pull/276))

--- a/common/util.ts
+++ b/common/util.ts
@@ -17,5 +17,5 @@ export const getMapLanguage = () => {
 };
 
 export function isEscapeKey(e: KeyboardEvent) {
-  return e.key === 'Escape';
+  return e.code === 'Escape';
 }

--- a/common/util.ts
+++ b/common/util.ts
@@ -15,3 +15,7 @@ export const getMapLanguage = () => {
   const languageCode = parts.length > 1 ? parts[0] : OSDLanguage;
   return OSD_LANGUAGES.includes(languageCode) ? languageCode : FALLBACK_LANGUAGE;
 };
+
+export function isEscapeKey(e: KeyboardEvent) {
+  return e.key === 'Escape';
+}

--- a/public/components/draw/modes/rectangle.ts
+++ b/public/components/draw/modes/rectangle.ts
@@ -5,6 +5,7 @@
 
 import { Feature, GeoJSON, Position } from 'geojson';
 import { DrawCustomMode, DrawFeature, DrawPolygon, MapMouseEvent } from '@mapbox/mapbox-gl-draw';
+import {isEscapeKey} from "../../../../common/util";
 
 // converted to typescript from
 // https://github.com/mapbox/geojson.io/blob/main/src/ui/draw/rectangle.js
@@ -96,7 +97,10 @@ export const DrawRectangle: DrawCustomMode<DrawRectangleState, {}> = {
     }
   },
   onKeyUp(state: DrawRectangleState, e: KeyboardEvent) {
-    if (e.code === 'Escape') {
+    if (isEscapeKey(e)) {
+      // delete feature on Escape, else, onStop will append feature and fires draw.create event
+      // @ts-ignore
+      this.deleteFeature([state.id], { silent: true });
       // change mode to simple select if escape is pressed
       // @ts-ignore
       this.changeMode('simple_select');

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -240,7 +240,11 @@ export const MapContainer = ({
         <DisplayFeatures map={maplibreRef.current!} layers={layers} />
       )}
       {mounted && Boolean(maplibreRef.current) && (
-        <DrawTooltip map={maplibreRef.current!} mode={filterProperties.mode} />
+        <DrawTooltip
+          map={maplibreRef.current!}
+          mode={filterProperties.mode}
+          onCancel={() => setFilterProperties({ mode: FILTER_DRAW_MODE.NONE })}
+        />
       )}
       {mounted && maplibreRef.current && tooltipState === TOOLTIP_STATE.FILTER_DRAW_SHAPE && (
         <DrawFilterShape

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -257,7 +257,7 @@ export const MapContainer = ({
         {mounted && (
           <SpatialFilterToolbar
             setFilterProperties={setFilterProperties}
-            isDrawActive={filterProperties.mode !== FILTER_DRAW_MODE.NONE}
+            mode={filterProperties.mode}
           />
         )}
       </div>

--- a/public/components/toolbar/spatial_filter/__snapshots__/filter_toolbar.test.tsx.snap
+++ b/public/components/toolbar/spatial_filter/__snapshots__/filter_toolbar.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`renders spatial filter before drawing 1`] = `
 >
   <EuiFlexItem>
     <FilterByPolygon
-      isDrawActive={false}
+      isDrawActive={true}
       setDrawFilterProperties={[MockFunction]}
     />
     <FilterByRectangle
-      isDrawActive={false}
+      isDrawActive={true}
       setDrawFilterProperties={[MockFunction]}
     />
   </EuiFlexItem>

--- a/public/components/toolbar/spatial_filter/__snapshots__/filter_toolbar.test.tsx.snap
+++ b/public/components/toolbar/spatial_filter/__snapshots__/filter_toolbar.test.tsx.snap
@@ -22,19 +22,11 @@ exports[`renders spatial filter before drawing 1`] = `
 
 exports[`renders spatial filter while drawing 1`] = `
 <EuiFlexGroup
+  alignItems="flexStart"
+  direction="column"
   gutterSize="s"
+  responsive={false}
 >
-  <EuiFlexItem
-    grow={false}
-  >
-    <EuiButton
-      fill={true}
-      onClick={[Function]}
-      size="s"
-    >
-      Cancel
-    </EuiButton>
-  </EuiFlexItem>
   <EuiFlexItem>
     <FilterByPolygon
       isDrawActive={true}

--- a/public/components/toolbar/spatial_filter/draw_tooltip.tsx
+++ b/public/components/toolbar/spatial_filter/draw_tooltip.tsx
@@ -7,10 +7,12 @@ import maplibregl, { Map as Maplibre, MapEventType, Popup } from 'maplibre-gl';
 import React, { Fragment, useEffect, useRef } from 'react';
 import { i18n } from '@osd/i18n';
 import { FILTER_DRAW_MODE } from '../../../../common';
+import {isEscapeKey} from "../../../../common/util";
 
 interface Props {
   map: Maplibre;
   mode: FILTER_DRAW_MODE;
+  onCancel: () => void;
 }
 
 const X_AXIS_GAP_BETWEEN_CURSOR_AND_POPUP = -12;
@@ -33,7 +35,7 @@ const getTooltipContent = (mode: FILTER_DRAW_MODE): string => {
   }
 };
 
-export const DrawTooltip = ({ map, mode }: Props) => {
+export const DrawTooltip = ({ map, mode, onCancel }: Props) => {
   const hoverPopupRef = useRef<Popup>(
     new maplibregl.Popup({
       closeButton: false,
@@ -58,12 +60,19 @@ export const DrawTooltip = ({ map, mode }: Props) => {
       hoverPopupRef.current.remove();
     }
 
+    function onKeyDown(e: KeyboardEvent) {
+      if (isEscapeKey(e)) {
+        onCancel();
+      }
+    }
+
     function resetAction() {
       map.getCanvas().style.cursor = '';
       hoverPopupRef.current.remove();
       // remove tooltip when users mouse move over a point
       map.off('mousemove', onMouseMoveMap);
       map.off('mouseout', onMouseMoveOut);
+      map.getContainer().removeEventListener('keydown', onKeyDown);
     }
 
     if (map && mode === FILTER_DRAW_MODE.NONE) {
@@ -72,6 +81,7 @@ export const DrawTooltip = ({ map, mode }: Props) => {
       // add tooltip when users mouse move over a point
       map.on('mousemove', onMouseMoveMap);
       map.on('mouseout', onMouseMoveOut);
+      map.getContainer().addEventListener('keydown', onKeyDown);
     }
     return () => {
       // remove tooltip when users mouse move over a point

--- a/public/components/toolbar/spatial_filter/filter_toolbar.tsx
+++ b/public/components/toolbar/spatial_filter/filter_toolbar.tsx
@@ -4,10 +4,10 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { FilterByPolygon } from './filter_by_polygon';
-import { FILTER_DRAW_MODE, DrawFilterProperties } from '../../../../common';
-import {FilterByRectangle} from "./filter_by_rectangle";
+import { DrawFilterProperties } from '../../../../common';
+import { FilterByRectangle } from './filter_by_rectangle';
 
 interface SpatialFilterToolBarProps {
   setFilterProperties: (properties: DrawFilterProperties) => void;
@@ -18,11 +18,6 @@ export const SpatialFilterToolbar = ({
   setFilterProperties,
   isDrawActive,
 }: SpatialFilterToolBarProps) => {
-  const onCancel = () => {
-    setFilterProperties({
-      mode: FILTER_DRAW_MODE.NONE,
-    });
-  };
   const filterIconGroups = (
     <EuiFlexItem>
       <FilterByPolygon setDrawFilterProperties={setFilterProperties} isDrawActive={isDrawActive} />
@@ -32,18 +27,6 @@ export const SpatialFilterToolbar = ({
       />
     </EuiFlexItem>
   );
-  if (isDrawActive) {
-    return (
-      <EuiFlexGroup gutterSize="s">
-        <EuiFlexItem grow={false}>
-          <EuiButton fill size="s" onClick={onCancel}>
-            {'Cancel'}
-          </EuiButton>
-        </EuiFlexItem>
-        {filterIconGroups}
-      </EuiFlexGroup>
-    );
-  }
   return (
     <EuiFlexGroup responsive={false} direction="column" alignItems="flexStart" gutterSize="s">
       {filterIconGroups}

--- a/public/components/toolbar/spatial_filter/filter_toolbar.tsx
+++ b/public/components/toolbar/spatial_filter/filter_toolbar.tsx
@@ -6,18 +6,16 @@
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { FilterByPolygon } from './filter_by_polygon';
-import { DrawFilterProperties } from '../../../../common';
+import { DrawFilterProperties, FILTER_DRAW_MODE } from '../../../../common';
 import { FilterByRectangle } from './filter_by_rectangle';
 
 interface SpatialFilterToolBarProps {
   setFilterProperties: (properties: DrawFilterProperties) => void;
-  isDrawActive: boolean;
+  mode: FILTER_DRAW_MODE;
 }
 
-export const SpatialFilterToolbar = ({
-  setFilterProperties,
-  isDrawActive,
-}: SpatialFilterToolBarProps) => {
+export const SpatialFilterToolbar = ({ setFilterProperties, mode }: SpatialFilterToolBarProps) => {
+  const isDrawActive: boolean = mode !== FILTER_DRAW_MODE.NONE;
   const filterIconGroups = (
     <EuiFlexItem>
       <FilterByPolygon setDrawFilterProperties={setFilterProperties} isDrawActive={isDrawActive} />


### PR DESCRIPTION
### Description
We will be using draw button as toggle. In the meantime, users can cancel once started drawing by pressing Escape key.


### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
