### PR TITLE
Add global geo shape filter while rendering data layers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Avoid trigger tooltip from label ([#350](https://github.com/opensearch-project/dashboards-maps/pull/350))
 * Add support to build GeoShapeFilterMeta and GeoShapeFilter ([#360](https://github.com/opensearch-project/dashboards-maps/pull/360))
 * Remove cancel button on draw shape and use Escape to cancel draw ([#359](https://github.com/opensearch-project/dashboards-maps/pull/359))
+* Add geoshape filter while render data layers ([#365](https://github.com/opensearch-project/dashboards-maps/pull/365)
 
 ### Bug Fixes
 * Fix property value undefined check ([#276](https://github.com/opensearch-project/dashboards-maps/pull/276))

--- a/common/index.ts
+++ b/common/index.ts
@@ -32,6 +32,7 @@ export const DOCUMENTS_MAX_MARKER_BORDER_THICKNESS = 100;
 export const DOCUMENTS_DEFAULT_REQUEST_NUMBER = 1000;
 export const DOCUMENTS_DEFAULT_SHOW_TOOLTIPS: boolean = false;
 export const DOCUMENTS_DEFAULT_DISPLAY_TOOLTIPS_ON_HOVER: boolean = true;
+export const DOCUMENTS_DEFAULT_APPLY_GLOBAL_FILTERS: boolean = true;
 export const DOCUMENTS_DEFAULT_TOOLTIPS: string[] = [];
 export const DOCUMENTS_DEFAULT_LABEL_ENABLES: boolean = false;
 export enum DOCUMENTS_LABEL_TEXT_TYPE {

--- a/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -235,6 +235,11 @@ export const DocumentLayerSource = ({
     setSelectedLayerConfig({ ...selectedLayerConfig, source });
   };
 
+  const onApplyGlobalFilters = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const source = { ...selectedLayerConfig.source, applyGlobalFilters: e.target.checked };
+    setSelectedLayerConfig({ ...selectedLayerConfig, source });
+  };
+
   const shouldTooltipSectionOpen = () => {
     return (
       selectedLayerConfig.source.showTooltips &&
@@ -354,6 +359,17 @@ export const DocumentLayerSource = ({
               label={'Only request data around map extent'}
               checked={selectedLayerConfig.source.useGeoBoundingBoxFilter ? true : false}
               onChange={onToggleGeoBoundingBox}
+              compressed
+            />
+          </EuiFormRow>
+          <EuiFormRow>
+            <EuiCheckbox
+              id={`${selectedLayerConfig.id}-apply-global-filter`}
+              label={i18n.translate('documentLayer.applyGlobalFilters', {
+                defaultMessage: 'Apply global filters',
+              })}
+              checked={selectedLayerConfig.source?.applyGlobalFilters ?? true}
+              onChange={onApplyGlobalFilters}
               compressed
             />
           </EuiFormRow>

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -161,6 +161,11 @@ export const MapContainer = ({
     return () => clearInterval(intervalId);
   }, [refreshConfig]);
 
+  // Update data layers when global filter is updated
+  useEffect(() => {
+    renderDataLayers(layers, mapState, services, maplibreRef, timeRange, filters, query);
+  }, [mapState.spatialMetaFilters]);
+
   useEffect(() => {
     if (!mounted || layers.length <= 0) {
       return;

--- a/public/model/mapLayerType.ts
+++ b/public/model/mapLayerType.ts
@@ -47,6 +47,7 @@ export type DocumentLayerSpecification = AbstractLayerSpecification & {
     tooltipFields: string[];
     useGeoBoundingBoxFilter: boolean;
     filters: Filter[];
+    applyGlobalFilters?: boolean;
   };
   style: {
     fillColor: string;

--- a/public/model/mapState.ts
+++ b/public/model/mapState.ts
@@ -1,4 +1,4 @@
-import { Query, TimeRange } from '../../../../src/plugins/data/common';
+import { GeoShapeFilterMeta, Query, TimeRange } from '../../../../src/plugins/data/common';
 
 export interface MapState {
   timeRange: TimeRange;
@@ -7,4 +7,5 @@ export interface MapState {
     pause: boolean;
     value: number;
   };
+  spatialMetaFilters?: GeoShapeFilterMeta[];
 }

--- a/public/utils/getIntialConfig.ts
+++ b/public/utils/getIntialConfig.ts
@@ -25,6 +25,7 @@ import {
   DOCUMENTS_DEFAULT_LABEL_COLOR,
   DOCUMENTS_DEFAULT_LABEL_BORDER_COLOR,
   DOCUMENTS_NONE_LABEL_BORDER_WIDTH,
+  DOCUMENTS_DEFAULT_APPLY_GLOBAL_FILTERS,
 } from '../../common';
 import { MapState } from '../model/mapState';
 import { ConfigSchema } from '../../common/config';
@@ -61,6 +62,7 @@ export const getLayerConfigMap = (mapConfig: ConfigSchema) => ({
       tooltipFields: DOCUMENTS_DEFAULT_TOOLTIPS,
       showTooltips: DOCUMENTS_DEFAULT_SHOW_TOOLTIPS,
       displayTooltipsOnHover: DOCUMENTS_DEFAULT_DISPLAY_TOOLTIPS_ON_HOVER,
+      applyGlobalFilters: DOCUMENTS_DEFAULT_APPLY_GLOBAL_FILTERS,
     },
     style: {
       ...getStyleColor(),


### PR DESCRIPTION
### Description

- Add geoshape filter to Map state.
- Refresh data layers if filter is updated.
- Add filter based on field type.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
