### PR TITLE
Add filter bar to display global geospatial filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add geoshape filter while render data layers ([#365](https://github.com/opensearch-project/dashboards-maps/pull/365)
 * Update listener on KeyUp ([#364](https://github.com/opensearch-project/dashboards-maps/pull/364))
 * Update draw filter shape ui properties ([#372](https://github.com/opensearch-project/dashboards-maps/pull/372))
+* Add filter bar to display global geospatial filters ([#371](https://github.com/opensearch-project/dashboards-maps/pull/371))
 
 ### Bug Fixes
 * Fix property value undefined check ([#276](https://github.com/opensearch-project/dashboards-maps/pull/276))

--- a/public/components/filter_bar/__snapshots__/filter_bar.test.tsx.snap
+++ b/public/components/filter_bar/__snapshots__/filter_bar.test.tsx.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders one filter inside filter bar 1`] = `
+<EuiFlexGroup
+  alignItems="flexStart"
+  className="globalFilterGroup"
+  gutterSize="none"
+  responsive={false}
+>
+  <EuiFlexItem
+    className="globalFilterGroup__branch"
+    grow={false}
+  >
+    <FilterOptions
+      onDisableAll={[Function]}
+      onEnableAll={[Function]}
+      onRemoveAll={[Function]}
+      onToggleAllDisabled={[Function]}
+      onToggleAllNegated={[Function]}
+    />
+  </EuiFlexItem>
+  <EuiFlexItem
+    className="globalFilterGroup__filterFlexItem"
+  >
+    <EuiFlexGroup
+      alignItems="center"
+      className="globalFilterBar some-class-name"
+      gutterSize="xs"
+      responsive={false}
+      wrap={true}
+    >
+      <EuiFlexItem
+        className="globalFilterBar__flexItem"
+        grow={false}
+        key="0"
+      >
+        <FilterItem
+          filterMeta={
+            Object {
+              "alias": "mylabel",
+              "disabled": false,
+              "negate": false,
+              "params": Object {
+                "relation": "intersects",
+                "shape": Object {
+                  "coordinates": Array [
+                    Array [
+                      Array [
+                        74.006,
+                        40.7128,
+                      ],
+                      Array [
+                        71.0589,
+                        42.3601,
+                      ],
+                      Array [
+                        73.7562,
+                        42.6526,
+                      ],
+                      Array [
+                        74.006,
+                        40.7128,
+                      ],
+                    ],
+                  ],
+                  "type": "Polygon",
+                },
+              },
+              "type": "geo_shape",
+            }
+          }
+          id="0"
+          onRemove={[Function]}
+          onUpdate={[Function]}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;

--- a/public/components/filter_bar/__snapshots__/filter_editor.test.tsx.snap
+++ b/public/components/filter_bar/__snapshots__/filter_editor.test.tsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders one filter inside filter bar 1`] = `
+<div>
+  <EuiPopoverTitle>
+    <EuiFlexGroup
+      alignItems="baseline"
+      responsive={false}
+    >
+      <EuiFlexItem>
+        Edit Filter
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiPopoverTitle>
+  <div
+    className="globalFilterItem__editorForm"
+  >
+    <EuiForm>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        fullWidth={true}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        label="Spatial filter parameters"
+        labelType="label"
+      >
+        <EuiCodeEditor
+          height="250px"
+          mode="json"
+          onChange={[Function]}
+          setOptions={Object {}}
+          value="\\"{}\\""
+          width="100%"
+        />
+      </EuiFormRow>
+      <div>
+        <EuiSpacer
+          size="m"
+        />
+        <EuiFormRow
+          describedByIds={Array []}
+          display="row"
+          fullWidth={true}
+          hasChildLabel={true}
+          hasEmptyLabelSpace={false}
+          label="Custom label"
+          labelType="label"
+        >
+          <EuiFieldText
+            fullWidth={true}
+            onChange={[Function]}
+            value="mylabel"
+          />
+        </EuiFormRow>
+      </div>
+      <EuiSpacer
+        size="m"
+      />
+      <EuiFlexGroup
+        alignItems="center"
+        direction="rowReverse"
+        responsive={false}
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <EuiButton
+            data-test-subj="saveFilter"
+            fill={true}
+            isDisabled={false}
+            onClick={[Function]}
+          >
+            Save
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={false}
+        >
+          <EuiButtonEmpty
+            data-test-subj="cancelSaveFilter"
+            flush="right"
+            onClick={[MockFunction]}
+          >
+            Cancel
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem />
+      </EuiFlexGroup>
+    </EuiForm>
+  </div>
+</div>
+`;

--- a/public/components/filter_bar/__snapshots__/filter_view.test.tsx.snap
+++ b/public/components/filter_bar/__snapshots__/filter_view.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test filter display renders filter display on disabled 1`] = `
+<EuiBadge
+  closeButtonProps={
+    Object {
+      "tabIndex": -1,
+    }
+  }
+  color="hollow"
+  iconOnClick={[MockFunction]}
+  iconOnClickAriaLabel="Delete"
+  iconSide="right"
+  iconType="cross"
+  onClick={[MockFunction]}
+  onClickAriaLabel="Filter actions"
+  title="Disabled Filter: mylabel. Select for more filter actions."
+>
+  mylabel
+</EuiBadge>
+`;
+
+exports[`test filter display renders filter display on enabled 1`] = `
+<EuiBadge
+  closeButtonProps={
+    Object {
+      "tabIndex": -1,
+    }
+  }
+  color="hollow"
+  iconOnClick={[MockFunction]}
+  iconOnClickAriaLabel="Delete"
+  iconSide="right"
+  iconType="cross"
+  onClick={[MockFunction]}
+  onClickAriaLabel="Filter actions"
+  title="Filter: mylabel. Select for more filter actions."
+>
+  mylabel
+</EuiBadge>
+`;

--- a/public/components/filter_bar/filter_actions.test.ts
+++ b/public/components/filter_bar/filter_actions.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {disableGeoShapeFilterMeta, enableGeoShapeFilterMeta, toggleGeoShapeFilterMetaNegated} from './filter_actions';
+import { GeoShapeFilterMeta } from '../../../../../src/plugins/data/common';
+
+describe('test filter actions', function () {
+  it('should enable GeoShapeFilterMeta', function () {
+    const updatedFilterMeta: GeoShapeFilterMeta = enableGeoShapeFilterMeta({
+      alias: null,
+      negate: false,
+      params: {},
+      disabled: true,
+    });
+    expect(updatedFilterMeta.disabled).toEqual(false);
+  });
+  it('should disable GeoShapeFilterMeta', function () {
+    const updatedFilterMeta: GeoShapeFilterMeta = disableGeoShapeFilterMeta({
+      alias: null,
+      negate: false,
+      params: {},
+      disabled: false,
+    });
+    expect(updatedFilterMeta.disabled).toEqual(true);
+  });
+  it('should toggle GeoShapeFilterMeta negation', function () {
+    const updatedFilterMeta: GeoShapeFilterMeta = toggleGeoShapeFilterMetaNegated({
+      alias: null,
+      negate: false,
+      params: {},
+      disabled: false,
+    });
+    expect(updatedFilterMeta.negate).toEqual(true);
+  });
+});

--- a/public/components/filter_bar/filter_actions.ts
+++ b/public/components/filter_bar/filter_actions.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GeoShapeFilterMeta } from '../../../../../src/plugins/data/common';
+
+export const enableGeoShapeFilterMeta = (meta: GeoShapeFilterMeta) =>
+  !meta.disabled ? meta : toggleGeoShapeFilterMetaDisabled(meta);
+
+export const disableGeoShapeFilterMeta = (meta: GeoShapeFilterMeta) =>
+  meta.disabled ? meta : toggleGeoShapeFilterMetaDisabled(meta);
+
+export const toggleGeoShapeFilterMetaNegated = (meta: GeoShapeFilterMeta) => {
+  const negate = !meta.negate;
+  return { ...meta, negate };
+};
+export const toggleGeoShapeFilterMetaDisabled = (meta: GeoShapeFilterMeta) => {
+  const status: boolean = !meta.disabled;
+  return { ...meta, disabled: status };
+};

--- a/public/components/filter_bar/filter_bar.test.tsx
+++ b/public/components/filter_bar/filter_bar.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import { FilterBar } from './filter_bar';
+import { FILTERS, GeoShapeFilterMeta, ShapeFilter } from '../../../../../src/plugins/data/common';
+import { GeoShapeRelation } from '@opensearch-project/opensearch/api/types';
+import { Polygon } from 'geojson';
+
+it('renders one filter inside filter bar', () => {
+  const mockCallback = jest.fn();
+  const mockPolygon: Polygon = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [74.006, 40.7128],
+        [71.0589, 42.3601],
+        [73.7562, 42.6526],
+        [74.006, 40.7128],
+      ],
+    ],
+  };
+  const expectedParams: {
+    shape: ShapeFilter;
+    relation: GeoShapeRelation;
+  } = {
+    shape: mockPolygon,
+    relation: 'intersects',
+  };
+  const mockFilterMeta: GeoShapeFilterMeta = {
+    alias: 'mylabel',
+    disabled: false,
+    negate: false,
+    type: FILTERS.GEO_SHAPE,
+    params: expectedParams,
+  };
+  const filterBar = shallow(
+    <FilterBar
+      filters={[mockFilterMeta]}
+      onFiltersUpdated={mockCallback}
+      className={'some-class-name'}
+    />
+  );
+  expect(filterBar).toMatchSnapshot();
+});

--- a/public/components/filter_bar/filter_bar.tsx
+++ b/public/components/filter_bar/filter_bar.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import classNames from 'classnames';
+import React from 'react';
+
+import { FilterItem } from './filter_item';
+import { GeoShapeFilterMeta } from '../../../../../src/plugins/data/common';
+import {
+  disableGeoShapeFilterMeta,
+  enableGeoShapeFilterMeta,
+  toggleGeoShapeFilterMetaDisabled,
+  toggleGeoShapeFilterMetaNegated,
+} from './filter_actions';
+import { FilterOptions } from './filter_options';
+
+interface Props {
+  filters: GeoShapeFilterMeta[];
+  onFiltersUpdated?: (filters: GeoShapeFilterMeta[]) => void;
+  className: string;
+}
+export const FilterBar = ({ filters, onFiltersUpdated, className }: Props) => {
+  function updateFilters(items: GeoShapeFilterMeta[]) {
+    if (onFiltersUpdated) {
+      onFiltersUpdated(items);
+    }
+  }
+
+  function renderItems(filterMeta: GeoShapeFilterMeta[]) {
+    return filterMeta.map((meta, i) => (
+      <EuiFlexItem key={i} grow={false} className="globalFilterBar__flexItem">
+        <FilterItem
+          id={`${i}`}
+          filterMeta={meta}
+          onUpdate={(newFilter) => onUpdate(i, newFilter)}
+          onRemove={() => onRemove(i)}
+        />
+      </EuiFlexItem>
+    ));
+  }
+
+  function onEnableAll() {
+    const updatedFilters: GeoShapeFilterMeta[] = filters.map(enableGeoShapeFilterMeta);
+    if (onFiltersUpdated) {
+      onFiltersUpdated(updatedFilters);
+    }
+  }
+
+  function onDisableAll() {
+    const updatedFilters: GeoShapeFilterMeta[] = filters.map(disableGeoShapeFilterMeta);
+    if (onFiltersUpdated) {
+      onFiltersUpdated(updatedFilters);
+    }
+  }
+
+  function onToggleAllNegated() {
+    const updatedFilters: GeoShapeFilterMeta[] = filters.map(toggleGeoShapeFilterMetaNegated);
+    if (onFiltersUpdated) {
+      onFiltersUpdated(updatedFilters);
+    }
+  }
+
+  function onToggleAllDisabled() {
+    const updatedFilters: GeoShapeFilterMeta[] = filters.map(toggleGeoShapeFilterMetaDisabled);
+    if (onFiltersUpdated) {
+      onFiltersUpdated(updatedFilters);
+    }
+  }
+
+  function onRemoveAll() {
+    if (onFiltersUpdated) {
+      onFiltersUpdated([]);
+    }
+  }
+
+  function onRemove(i: number) {
+    const updatedFilters = [...filters];
+    updatedFilters.splice(i, 1);
+    updateFilters(updatedFilters);
+  }
+
+  function onUpdate(i: number, filter: GeoShapeFilterMeta) {
+    const current = [...filters];
+    current[i] = filter;
+    updateFilters(current);
+  }
+
+  const classes = classNames('globalFilterBar', className);
+
+  return (
+    <EuiFlexGroup
+      className="globalFilterGroup"
+      gutterSize="none"
+      alignItems="flexStart"
+      responsive={false}
+    >
+      <EuiFlexItem className="globalFilterGroup__branch" grow={false}>
+        <FilterOptions
+          onEnableAll={onEnableAll}
+          onDisableAll={onDisableAll}
+          onToggleAllNegated={onToggleAllNegated}
+          onToggleAllDisabled={onToggleAllDisabled}
+          onRemoveAll={onRemoveAll}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem className="globalFilterGroup__filterFlexItem">
+        <EuiFlexGroup
+          className={classes}
+          wrap={true}
+          responsive={false}
+          gutterSize="xs"
+          alignItems="center"
+        >
+          {renderItems(filters)}
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/public/components/filter_bar/filter_editor.test.tsx
+++ b/public/components/filter_bar/filter_editor.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import { FilterEditor } from './filter_editor';
+
+it('renders one filter inside filter bar', () => {
+  const mockOnSubmitCallback = jest.fn();
+  const mockOnCancelCallback = jest.fn();
+  const filterEditor = shallow(
+    <FilterEditor
+      content={JSON.stringify('{}')}
+      label={'mylabel'}
+      onCancel={mockOnCancelCallback}
+      onSubmit={mockOnSubmitCallback}
+    />
+  );
+  expect(filterEditor).toMatchSnapshot();
+});

--- a/public/components/filter_bar/filter_editor.tsx
+++ b/public/components/filter_bar/filter_editor.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCodeEditor,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiForm,
+  EuiFormRow,
+  EuiPopoverTitle,
+  EuiSpacer,
+} from '@elastic/eui';
+import React, { useState } from 'react';
+import { i18n } from '@osd/i18n';
+
+interface Props {
+  content: string;
+  label: string;
+  onSubmit: (content: string, label: string) => void;
+  onCancel: () => void;
+}
+
+const isFilterValid = (content: string) => {
+  try {
+    return Boolean(JSON.parse(content));
+  } catch (e) {
+    return false;
+  }
+};
+
+export const FilterEditor = ({ content, label, onSubmit, onCancel }: Props) => {
+  const [filterLabel, setFilterLabel] = useState<string>(label);
+  const [filterContent, setFilterContent] = useState<string>(content);
+
+  const renderEditor = () => {
+    return (
+      <EuiFormRow
+        label={i18n.translate('maps.filter.filterEditor.parameters', {
+          defaultMessage: 'Spatial filter parameters',
+        })}
+        fullWidth={true}
+      >
+        <EuiCodeEditor
+          value={filterContent}
+          onChange={setFilterContent}
+          mode="json"
+          width="100%"
+          height="250px"
+        />
+      </EuiFormRow>
+    );
+  };
+  return (
+    <div>
+      <EuiPopoverTitle>
+        <EuiFlexGroup alignItems="baseline" responsive={false}>
+          <EuiFlexItem>{'Edit Filter'}</EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPopoverTitle>
+
+      <div className="globalFilterItem__editorForm">
+        <EuiForm>
+          {renderEditor()}
+          <div>
+            <EuiSpacer size="m" />
+            <EuiFormRow
+              fullWidth={true}
+              label={i18n.translate('maps.filter.filterEditor.createCustomLabelInputLabel', {
+                defaultMessage: 'Custom label',
+              })}
+            >
+              <EuiFieldText
+                fullWidth={true}
+                value={filterLabel}
+                onChange={(event) => setFilterLabel(event.target.value)}
+              />
+            </EuiFormRow>
+          </div>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup direction="rowReverse" alignItems="center" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                fill
+                onClick={() => onSubmit(filterContent, filterLabel)}
+                isDisabled={!isFilterValid(filterContent)}
+                data-test-subj="saveFilter"
+              >
+                {'Save'}
+              </EuiButton>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty flush="right" onClick={onCancel} data-test-subj="cancelSaveFilter">
+                {'Cancel'}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem />
+          </EuiFlexGroup>
+        </EuiForm>
+      </div>
+    </div>
+  );
+};

--- a/public/components/filter_bar/filter_item.tsx
+++ b/public/components/filter_bar/filter_item.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiContextMenu, EuiPopover } from '@elastic/eui';
+import classNames from 'classnames';
+import React, { MouseEvent, useState } from 'react';
+import { i18n } from '@osd/i18n';
+import { GeoShapeFilterMeta } from '../../../../../src/plugins/data/common';
+import { FilterView } from './filter_view';
+import {
+  toggleGeoShapeFilterMetaDisabled,
+  toggleGeoShapeFilterMetaNegated,
+} from './filter_actions';
+import { FilterEditor } from './filter_editor';
+
+interface Props {
+  id: string;
+  filterMeta: GeoShapeFilterMeta;
+  className?: string;
+  onUpdate: (filter: GeoShapeFilterMeta) => void;
+  onRemove: () => void;
+}
+
+export function FilterItem({ filterMeta, onUpdate, onRemove, id, className }: Props) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+
+  function onSubmit(content: string, label: string) {
+    setIsPopoverOpen(false);
+    const updatedFilter: GeoShapeFilterMeta = {
+      ...filterMeta,
+      params: JSON.parse(content),
+      alias: label,
+    };
+    onUpdate(updatedFilter);
+  }
+
+  function handleClick(e: MouseEvent<HTMLInputElement>) {
+    if (e.shiftKey) {
+      onToggleDisabled();
+    } else {
+      setIsPopoverOpen(!isPopoverOpen);
+    }
+  }
+
+  function onToggleNegated() {
+    const f = toggleGeoShapeFilterMetaNegated(filterMeta);
+    onUpdate(f);
+  }
+
+  function onToggleDisabled() {
+    const f = toggleGeoShapeFilterMetaDisabled(filterMeta);
+    onUpdate(f);
+  }
+
+  function getClasses(negate: boolean, disabled: boolean) {
+    return classNames(
+      'globalFilterItem',
+      {
+        'globalFilterItem-isDisabled': disabled,
+        'globalFilterItem-isExcluded': negate,
+      },
+      className
+    );
+  }
+
+  function getDataTestSubj() {
+    const dataTestSubjKey = filterMeta.key ? `filter-key-${filterMeta.key}` : '';
+    const dataTestSubjValue = filterMeta.value;
+    const dataTestSubjNegated = filterMeta.negate ? 'filter-negated' : '';
+    const dataTestSubjDisabled = `filter-${filterMeta.disabled ? 'disabled' : 'enabled'}`;
+    return `filter ${dataTestSubjDisabled} ${dataTestSubjKey} ${dataTestSubjValue} ${dataTestSubjNegated}`;
+  }
+
+  function getPanels() {
+    const { negate, disabled } = filterMeta;
+    return [
+      {
+        id: 0,
+        items: [
+          {
+            name: i18n.translate('maps.filter.filterBar.editFilterButtonLabel', {
+              defaultMessage: 'Edit filter',
+            }),
+            icon: 'pencil',
+            panel: 1,
+            'data-test-subj': 'editFilter',
+          },
+          {
+            name: negate
+              ? i18n.translate('maps.filter.filterBar.includeFilterButtonLabel', {
+                  defaultMessage: 'Include results',
+                })
+              : i18n.translate('data.filter.filterBar.excludeFilterButtonLabel', {
+                  defaultMessage: 'Exclude results',
+                }),
+            icon: negate ? 'plusInCircle' : 'minusInCircle',
+            onClick: () => {
+              setIsPopoverOpen(false);
+              onToggleNegated();
+            },
+            'data-test-subj': 'negateFilter',
+          },
+          {
+            name: disabled
+              ? i18n.translate('data.filter.filterBar.enableFilterButtonLabel', {
+                  defaultMessage: 'Re-enable',
+                })
+              : i18n.translate('data.filter.filterBar.disableFilterButtonLabel', {
+                  defaultMessage: 'Temporarily disable',
+                }),
+            icon: `${disabled ? 'eye' : 'eyeClosed'}`,
+            onClick: () => {
+              setIsPopoverOpen(false);
+              onToggleDisabled();
+            },
+            'data-test-subj': 'disableFilter',
+          },
+          {
+            name: i18n.translate('data.filter.filterBar.deleteFilterButtonLabel', {
+              defaultMessage: 'Delete',
+            }),
+            icon: 'trash',
+            onClick: () => {
+              setIsPopoverOpen(false);
+              onRemove();
+            },
+            'data-test-subj': 'deleteFilter',
+          },
+        ],
+      },
+      {
+        id: 1,
+        width: 600,
+        content: (
+          <div>
+            <FilterEditor
+              content={JSON.stringify(filterMeta.params, null, 2)}
+              label={filterMeta.alias!}
+              onSubmit={onSubmit}
+              onCancel={() => {
+                setIsPopoverOpen(false);
+              }}
+            />
+          </div>
+        ),
+      },
+    ];
+  }
+
+  const badge = (
+    <FilterView
+      isDisabled={filterMeta.disabled}
+      className={getClasses(filterMeta.negate, filterMeta.disabled)}
+      onRemove={onRemove}
+      valueLabel={filterMeta.alias || ''}
+      onClick={handleClick}
+      data-test-subj={getDataTestSubj()}
+    />
+  );
+
+  return (
+    <EuiPopover
+      id={`popoverFor_filter${id}`}
+      className={`globalFilterItem__popover`}
+      anchorClassName={`globalFilterItem__popoverAnchor`}
+      isOpen={isPopoverOpen}
+      closePopover={() => {
+        setIsPopoverOpen(false);
+      }}
+      button={badge}
+      anchorPosition="downLeft"
+      panelPaddingSize="none"
+    >
+      <EuiContextMenu initialPanelId={0} panels={getPanels()} />
+    </EuiPopover>
+  );
+}

--- a/public/components/filter_bar/filter_options.tsx
+++ b/public/components/filter_bar/filter_options.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
+import React, { useState } from 'react';
+import { i18n } from '@osd/i18n';
+
+interface Props {
+  onEnableAll: () => void;
+  onDisableAll: () => void;
+  onToggleAllNegated: () => void;
+  onToggleAllDisabled: () => void;
+  onRemoveAll: () => void;
+}
+
+export const FilterOptions = ({
+  onEnableAll,
+  onDisableAll,
+  onToggleAllNegated,
+  onToggleAllDisabled,
+  onRemoveAll,
+}: Props) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+
+  const togglePopover = () => {
+    setIsPopoverOpen(!isPopoverOpen);
+  };
+  const closePopover = () => {
+    setIsPopoverOpen(false);
+  };
+
+  const panelTree = {
+    id: 0,
+    items: [
+      {
+        name: i18n.translate('maps.filter.options.enableAllFiltersButtonLabel', {
+          defaultMessage: 'Enable all',
+        }),
+        icon: 'eye',
+        onClick: () => {
+          closePopover();
+          onEnableAll();
+        },
+        'data-test-subj': 'enableAllFilters',
+      },
+      {
+        name: i18n.translate('maps.filter.options.disableAllFiltersButtonLabel', {
+          defaultMessage: 'Disable all',
+        }),
+        icon: 'eyeClosed',
+        onClick: () => {
+          closePopover();
+          onDisableAll();
+        },
+        'data-test-subj': 'disableAllFilters',
+      },
+      {
+        name: i18n.translate('maps.filter.options.invertNegatedFiltersButtonLabel', {
+          defaultMessage: 'Invert inclusion',
+        }),
+        icon: 'invert',
+        onClick: () => {
+          closePopover();
+          onToggleAllNegated();
+        },
+        'data-test-subj': 'invertInclusionAllFilters',
+      },
+      {
+        name: i18n.translate('maps.filter.options.invertDisabledFiltersButtonLabel', {
+          defaultMessage: 'Invert enabled/disabled',
+        }),
+        icon: 'eye',
+        onClick: () => {
+          closePopover();
+          onToggleAllDisabled();
+        },
+        'data-test-subj': 'invertEnableDisableAllFilters',
+      },
+      {
+        name: i18n.translate('maps.filter.options.deleteAllFiltersButtonLabel', {
+          defaultMessage: 'Remove all',
+        }),
+        icon: 'trash',
+        onClick: () => {
+          closePopover();
+          onRemoveAll();
+        },
+        'data-test-subj': 'removeAllFilters',
+      },
+    ],
+  };
+
+  return (
+    <EuiPopover
+      id="popoverForAllFilters"
+      className="globalFilterGroup__allFiltersPopover"
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      button={
+        <EuiButtonIcon
+          onClick={togglePopover}
+          iconType="filter"
+          aria-label={i18n.translate('maps.filter.options.changeAllFiltersButtonLabel', {
+            defaultMessage: 'Change all filters',
+          })}
+          title={i18n.translate('maps.filter.options.changeAllFiltersButtonLabel', {
+            defaultMessage: 'Change all filters',
+          })}
+          data-test-subj="showFilterActions"
+        />
+      }
+      anchorPosition="rightUp"
+      panelPaddingSize="none"
+      repositionOnScroll
+    >
+      <EuiPopoverTitle>
+        {i18n.translate('maps.filter.changeAllFiltersTitle', {
+          defaultMessage: 'Change all filters',
+        })}
+      </EuiPopoverTitle>
+      <EuiContextMenu initialPanelId={0} panels={[panelTree]} />
+    </EuiPopover>
+  );
+};

--- a/public/components/filter_bar/filter_view.test.tsx
+++ b/public/components/filter_bar/filter_view.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import { FilterView } from './filter_view';
+
+describe('test filter display', function () {
+  it('renders filter display on disabled', () => {
+    const mockOnClick = jest.fn();
+    const mockOnRemove = jest.fn();
+    const filterBar = shallow(
+      <FilterView
+        isDisabled={true}
+        valueLabel={'mylabel'}
+        onClick={mockOnClick}
+        onRemove={mockOnRemove}
+      />
+    );
+    expect(filterBar).toMatchSnapshot();
+  });
+  it('renders filter display on enabled', () => {
+    const mockOnClick = jest.fn();
+    const mockOnRemove = jest.fn();
+    const filterView = shallow(
+      <FilterView
+        isDisabled={false}
+        valueLabel={'mylabel'}
+        onClick={mockOnClick}
+        onRemove={mockOnRemove}
+      />
+    );
+    expect(filterView).toMatchSnapshot();
+  });
+});

--- a/public/components/filter_bar/filter_view.tsx
+++ b/public/components/filter_bar/filter_view.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiBadge } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import React, { FC } from 'react';
+
+interface Props {
+  isDisabled: boolean;
+  valueLabel: string;
+  onRemove: () => void;
+  [propName: string]: any;
+}
+
+export const FilterView: FC<Props> = ({
+  isDisabled,
+  onRemove,
+  onClick,
+  valueLabel,
+  ...rest
+}: Props) => {
+  let title = i18n.translate('maps.filter.filterBar.moreFilterActionsMessage', {
+    defaultMessage: 'Filter: {valueLabel}. Select for more filter actions.',
+    values: { valueLabel },
+  });
+
+  if (isDisabled) {
+    title = `${i18n.translate('maps.filter.filterBar.disabledFilterPrefix', {
+      defaultMessage: 'Disabled',
+    })} ${title}`;
+  }
+
+  return (
+    <EuiBadge
+      title={title}
+      color="hollow"
+      iconType="cross"
+      iconSide="right"
+      closeButtonProps={{
+        // Removing tab focus on close button because the same option can be obtained through the context menu
+        // Also, we may want to add a `DEL` keyboard press functionality
+        tabIndex: -1,
+      }}
+      iconOnClick={onRemove}
+      iconOnClickAriaLabel={i18n.translate('maps.filter.filterBar.filterItemBadgeIconAriaLabel', {
+        defaultMessage: 'Delete',
+      })}
+      onClick={onClick}
+      onClickAriaLabel={i18n.translate('maps.filter.filterBar.filterItemBadgeAriaLabel', {
+        defaultMessage: 'Filter actions',
+      })}
+      {...rest}
+    >
+      {valueLabel}
+    </EuiBadge>
+  );
+};

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -6,6 +6,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Map as Maplibre, NavigationControl } from 'maplibre-gl';
 import { debounce, throttle } from 'lodash';
+import { GeoShapeRelation } from '@opensearch-project/opensearch/api/types';
 import { LayerControlPanel } from '../layer_control_panel';
 import './map_container.scss';
 import { DrawFilterProperties, FILTER_DRAW_MODE, MAP_INITIAL_STATE } from '../../../common';
@@ -36,6 +37,7 @@ import { DisplayFeatures } from '../tooltip/display_features';
 import { TOOLTIP_STATE } from '../../../common';
 import { SpatialFilterToolbar } from '../toolbar/spatial_filter/filter_toolbar';
 import { DrawFilterShapeHelper } from '../toolbar/spatial_filter/display_draw_helper';
+import { ShapeFilter } from '../../../../../src/plugins/data/common';
 
 interface MapContainerProps {
   setLayers: (layers: MapLayerSpecification[]) => void;
@@ -52,6 +54,7 @@ interface MapContainerProps {
   query?: Query;
   isUpdatingLayerRender: boolean;
   setIsUpdatingLayerRender: (isUpdatingLayerRender: boolean) => void;
+  addSpatialFilter: (shape: ShapeFilter, label: string | null, relation: GeoShapeRelation) => void;
 }
 
 export const MapContainer = ({
@@ -69,6 +72,7 @@ export const MapContainer = ({
   query,
   isUpdatingLayerRender,
   setIsUpdatingLayerRender,
+  addSpatialFilter,
 }: MapContainerProps) => {
   const { services } = useOpenSearchDashboards<MapServices>();
   const mapContainer = useRef(null);
@@ -256,10 +260,11 @@ export const MapContainer = ({
           map={maplibreRef.current}
           filterProperties={filterProperties}
           updateFilterProperties={setFilterProperties}
+          addSpatialFilter={addSpatialFilter}
         />
       )}
       <div className="SpatialFilterToolbar-container">
-        {mounted && (
+        {!isReadOnlyMode && mounted && (
           <SpatialFilterToolbar
             setFilterProperties={setFilterProperties}
             mode={filterProperties.mode}

--- a/public/components/toolbar/spatial_filter/draw_filter_shape.tsx
+++ b/public/components/toolbar/spatial_filter/draw_filter_shape.tsx
@@ -7,6 +7,7 @@ import React, { Fragment, useEffect, useRef } from 'react';
 import { IControl, Map as Maplibre } from 'maplibre-gl';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import { Feature } from 'geojson';
+import { GeoShapeRelation } from '@opensearch-project/opensearch/api/types';
 import {
   DrawFilterProperties,
   FILTER_DRAW_MODE,
@@ -15,11 +16,13 @@ import {
 } from '../../../../common';
 import { DrawRectangle } from '../../draw/modes/rectangle';
 import {DRAW_SHAPE_STYLE} from "./draw_style";
+import { GeoShapeFilter, ShapeFilter } from '../../../../../../src/plugins/data/common';
 
 interface DrawFilterShapeProps {
   filterProperties: DrawFilterProperties;
   map: Maplibre;
   updateFilterProperties: (properties: DrawFilterProperties) => void;
+  addSpatialFilter: (shape: ShapeFilter, label: string | null, relation: GeoShapeRelation) => void;
 }
 
 function getMapboxDrawMode(mode: FILTER_DRAW_MODE): string {
@@ -32,13 +35,41 @@ function getMapboxDrawMode(mode: FILTER_DRAW_MODE): string {
       return MAPBOX_GL_DRAW_MODES.SIMPLE_SELECT;
   }
 }
+export const isGeoShapeFilter = (filter: any): filter is GeoShapeFilter => filter?.geo_shape;
+
+const isShapeFilter = (geometry: any): geometry is ShapeFilter => {
+  return geometry && (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon');
+};
+
+const toGeoShapeRelation = (relation?: string): GeoShapeRelation => {
+  switch (relation) {
+    case 'intersects':
+      return relation;
+    case 'within':
+      return relation;
+    case 'disjoint':
+      return relation;
+    default:
+      return 'intersects';
+  }
+};
 
 export const DrawFilterShape = ({
   filterProperties,
   map,
   updateFilterProperties,
+  addSpatialFilter,
 }: DrawFilterShapeProps) => {
   const onDraw = (event: { features: Feature[] }) => {
+    event.features.map((feature) => {
+      if (isShapeFilter(feature.geometry)) {
+        addSpatialFilter(
+          feature.geometry,
+          filterProperties.filterLabel || null,
+          toGeoShapeRelation(filterProperties.relation)
+        );
+      }
+    });
     updateFilterProperties({
       mode: FILTER_DRAW_MODE.NONE,
     });

--- a/public/components/toolbar/spatial_filter/spatial_filter.scss
+++ b/public/components/toolbar/spatial_filter/spatial_filter.scss
@@ -7,10 +7,9 @@
   position: relative;
 
   .euiButtonIcon {
-    border-color:rgba(0,0,0,0.9);
-    color:rgba(255,255,255,0.5);
     width:30px;
     height:30px;
+    border: transparent;
   }
 }
 .spatialFilterGroup__popoverPanel{

--- a/public/model/layerRenderController.ts
+++ b/public/model/layerRenderController.ts
@@ -138,7 +138,7 @@ export const handleDataLayerRender = (
   filters.push(geoBoundingBoxFilter);
 
   // build and add GeoShape filters from map state if applicable
-  if (mapLayer.source?.applyGlobalFilter ?? true) {
+  if (mapLayer.source?.applyGlobalFilters ?? true) {
     mapState?.spatialMetaFilters?.map((value) => {
       if (getSupportedOperations(geoFieldType).includes(value.params.relation)) {
         filters.push(buildGeoShapeFilter(geoField, value));


### PR DESCRIPTION
### Description
Add spatial filter after drawing shape from tool bar.
This also provide options like edit, delete, enable, disable on every filter once added.
If draw filter is active, update button color to display which one is active.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
