### PR TITLE
Fix cypress test failed due to OSD dashboard create button updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 * Add CHANGELOG ([#342](https://github.com/opensearch-project/dashboards-maps/pull/342))
 * Add stats API for maps and layers in maps plugin ([#362](https://github.com/opensearch-project/dashboards-maps/pull/362))
+* Fix cypress test failed due to OSD dashboard create button updated ([#393](https://github.com/opensearch-project/dashboards-maps/pull/393))
 
 ### Documentation
 

--- a/cypress/integration/add_map_to_dashboard.spec.js
+++ b/cypress/integration/add_map_to_dashboard.spec.js
@@ -20,7 +20,7 @@ describe('Add map to dashboard', () => {
   it('Add new map to dashboard', () => {
     const testMapName = 'saved-map-' + Date.now().toString();
     cy.visit(`${BASE_PATH}/app/dashboards`);
-    cy.get('button[data-test-subj="newItemButton"]').click();
+    cy.get('[data-test-subj="newItemButton"]').click();
     cy.get('button[data-test-subj="dashboardAddNewPanelButton"]').click();
     cy.get('button[data-test-subj="visType-customImportMap"]').click();
     cy.wait(5000).get('button[data-test-subj="mapSaveButton"]').click();


### PR DESCRIPTION
### Description

Fix cypress test failed due to OSD dashboard create button updated

Ref: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3090

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
