### PR TITLE
Fix failing cypress test

### DIFF
--- a/cypress/integration/add_saved_object.spec.js
+++ b/cypress/integration/add_saved_object.spec.js
@@ -7,13 +7,10 @@ import { BASE_PATH } from '../utils/constants';
 
 describe('Add flights dataset saved object', () => {
   before(() => {
-    cy.visit(`${BASE_PATH}/app/maps-dashboards`, {
+    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
       retryOnStatusCodeFailure: true,
       timeout: 60000,
     });
-    cy.get('div[data-test-subj="indexPatternEmptyState"]', { timeout: 60000 })
-      .contains(/Add sample data/)
-      .click();
     cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
       .contains(/Add data/)
       .click();


### PR DESCRIPTION
### Description
Fix the failing cypress test `add_saved_object.spec.js`
Recording of failed test - https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.7.0/6100/linux/x64/tar/test-results/3473/integ-test/functionalTestDashboards/with-security/test-results/cypress-videos/plugins/custom-import-map-dashboards/add_saved_object.spec.js.mp4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
