### PR TITLE
Fix: CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/dashboards-maps
+# This should match the list in MAINTAINERS.md.
+* @VijayanB @vamshin @junqiu-lei


### PR DESCRIPTION
### Description

The team is going away, replaced by the list of people in MAINTAINERS.md.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
