### PR TITLE
[backport 2.x][manually]Update repo owners and maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/dashboards-maps
+# This should match the list in MAINTAINERS.md.
+* @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,11 +4,16 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                   | Affiliation |
-|-------------------------|---------------------------------------------| ----------- |
-| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)     | Amazon      |
-| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)       | Amazon      |
-| Junqiu Lei              | [junqiu-lei](https://github.com/junqiu-lei) | Amazon      |
+| Maintainer              | GitHub ID                                             | Affiliation |
+|-------------------------|-------------------------------------------------------|-------------|
+| Heemin Kim              | [heemin32](https://github.com/heemin32)               | Amazon      |
+| Jack Mazanec            | [jmazanec15](https://github.com/jmazanec15)           | Amazon      |
+| Junqiu Lei              | [junqiu-lei](https://github.com/junqiu-lei)           | Amazon      |
+| Martin Gaievski         | [martin-gaievski](https://github.com/martin-gaievski) | Amazon      |
+| Naveen Tatikonda        | [naveentatikonda](https://github.com/naveentatikonda) | Amazon      |
+| Navneet Verma           | [navneet1v](https://github.com/navneet1v)             | Amazon      |
+| Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)                 | Amazon      |
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)               | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/dashboards-maps/pull/414 to 2.x


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
