### PR TITLE
Allow filtering geo_shape fields around map extent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 ### Refactoring
 
-## [Unreleased 2.x](https://github.com/opensearch-project/dashboards-maps/compare/2.8...2.x)
+## [Unreleased 2.x](https://github.com/opensearch-project/dashboards-maps/compare/2.9...2.x)
 ### Features
+* Allow filtering geo_shape fields around map extent ([#452](https://github.com/opensearch-project/dashboards-maps/pull/452))
 
 ### Enhancements
 

--- a/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -355,7 +355,6 @@ export const DocumentLayerSource = ({
           <EuiFormRow>
             <EuiCheckbox
               id={`${selectedLayerConfig.id}-bounding-box-filter`}
-              disabled={selectedLayerConfig.source.geoFieldType !== 'geo_point'}
               label={'Only request data around map extent'}
               checked={selectedLayerConfig.source.useGeoBoundingBoxFilter ? true : false}
               onChange={onToggleGeoBoundingBox}

--- a/public/model/layerRenderController.ts
+++ b/public/model/layerRenderController.ts
@@ -167,13 +167,12 @@ const getGeoBoundingBoxFilter = (
   maplibreRef: MaplibreRef
 ): GeoBoundingBoxFilter => {
   const geoField = mapLayer.source.geoFieldName;
-  const geoFieldType = mapLayer.source.geoFieldType;
 
   // geo bounding box query supports geo_point fields
   const mapBounds: GeoBounds = getBounds(maplibreRef.current!);
   const meta: FilterMeta = {
     alias: null,
-    disabled: !mapLayer.source.useGeoBoundingBoxFilter || geoFieldType !== 'geo_point',
+    disabled: !mapLayer.source.useGeoBoundingBoxFilter,
     negate: false,
     type: FILTERS.GEO_BOUNDING_BOX,
   };


### PR DESCRIPTION
### Description
From 2.9, geoshape supports geo bounding box. Hence, remove the constraint that disables geo bounding box for non geopoint fields.



https://github.com/opensearch-project/dashboards-maps/assets/11067894/1217990f-006f-444f-a27f-26aeaa613ba6



### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
