### PR TITLE
Add wait time after selecting a color

### DIFF
--- a/cypress/e2e/documentsLayer.cy.js
+++ b/cypress/e2e/documentsLayer.cy.js
@@ -36,9 +36,9 @@ describe('Documents layer', () => {
     cy.get(`button[testSubj="styleTab"]`).click();
     cy.contains('Fill color').click();
     cy.get(`button[aria-label="Select #E7664C as the color"]`).click();
-    cy.contains('Border color').click();
+    cy.wait(1000).contains('Border color').click();
     cy.get(`button[aria-label="Select #DA8B45 as the color"]`).click();
-    cy.get(`button[testSubj="settingsTab"]`).click();
+    cy.wait(1000).get(`button[testSubj="settingsTab"]`).click();
     cy.get('[name="layerName"]').clear().type('Documents layer 1');
     cy.get(`button[data-test-subj="updateButton"]`).click();
     cy.get('[data-test-subj="layerControlPanel"]').should('contain', 'Documents layer 1');


### PR DESCRIPTION
### Description
After selecting a color from color palette, it takes time for the palette to disappear and it could cause two palette to be visible at the same time which could cause an error like `Your subject contained 2 elements.`

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
