### PR TITLE
Fixed maps tooltip display at dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+* Fixed maps tooltip display at dark mode[#564](https://github.com/opensearch-project/dashboards-maps/pull/564)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/public/components/tooltip/create_tooltip.scss
+++ b/public/components/tooltip/create_tooltip.scss
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.mapTooltip {
+  div.maplibregl-popup-content.mapboxgl-popup-content {
+    padding: 0;
+    background: none;
+  }
+}
+
+.maplibregl-popup-anchor-top {
+  .maplibregl-popup-tip {
+    border-bottom-color:lightOrDarkTheme($ouiColorEmptyShade, $ouiColorLightestShade) !important;
+  }
+}
+
+.maplibregl-popup-anchor-bottom {
+  .maplibregl-popup-tip {
+    border-top-color:lightOrDarkTheme($ouiColorEmptyShade, $ouiColorLightestShade) !important;
+  }
+}
+
+.maplibregl-popup-anchor-left {
+  .maplibregl-popup-tip {
+    border-right-color:lightOrDarkTheme($ouiColorEmptyShade, $ouiColorLightestShade) !important;
+  }
+}
+
+.maplibregl-popup-anchor-right {
+  .maplibregl-popup-tip {
+    border-left-color:lightOrDarkTheme($ouiColorEmptyShade, $ouiColorLightestShade) !important;
+  }
+}

--- a/public/components/tooltip/create_tooltip.tsx
+++ b/public/components/tooltip/create_tooltip.tsx
@@ -5,6 +5,7 @@ import { Popup, MapGeoJSONFeature, LngLat } from 'maplibre-gl';
 import { MapLayerSpecification, DocumentLayerSpecification } from '../../model/mapLayerType';
 import { FeatureGroupItem, TooltipContainer } from './tooltipContainer';
 import { MAX_LONGITUDE } from '../../../common';
+import './create_tooltip.scss';
 
 interface Options {
   features: MapGeoJSONFeature[];
@@ -76,6 +77,7 @@ export function createPopup({
     closeButton: false,
     closeOnClick: false,
     maxWidth: 'max-content',
+    className: 'mapTooltip',
   });
 
   const featureGroup = groupFeaturesByLayers(features, layers);

--- a/public/components/tooltip/tooltipTable.tsx
+++ b/public/components/tooltip/tooltipTable.tsx
@@ -15,13 +15,16 @@ import {
 } from '@elastic/eui';
 import React, { useState, Fragment, useCallback, useEffect, useMemo } from 'react';
 
-export type RowData = {
+export interface RowData {
   key: string;
   value: string;
-};
+}
 export type PageData = RowData[];
 export type TableData = PageData[];
-type Table = { table: TableData; layer: string };
+interface Table {
+  table: TableData;
+  layer: string;
+}
 
 export const ALL_LAYERS = -1;
 
@@ -66,7 +69,7 @@ const TooltipTable = ({
   showPagination = true,
   showLayerSelection = true,
 }: Props) => {
-  const [selectedLayers, setSelectedLayers] = useState<EuiComboBoxOptionOption<number>[]>([
+  const [selectedLayers, setSelectedLayers] = useState<Array<EuiComboBoxOptionOption<number>>>([
     {
       label: tables[0]?.layer ?? '',
       value: 0,
@@ -103,7 +106,7 @@ const TooltipTable = ({
   };
 
   const handleLayerChange = useCallback(
-    (layerSelections: EuiComboBoxOptionOption<number>[]) => {
+    (layerSelections: Array<EuiComboBoxOptionOption<number>>) => {
       if (tables.length === 0) {
         return;
       }
@@ -152,7 +155,7 @@ const TooltipTable = ({
   return (
     <Fragment>
       <EuiFlexGroup responsive={false}>
-        <EuiFlexItem style={{ overflow: 'scroll', maxHeight: 300 }}>
+        <EuiFlexItem style={{ overflow: 'auto', maxHeight: 300 }}>
           <EuiBasicTable
             isSelectable={false}
             items={pageItems}


### PR DESCRIPTION
### Description
Followed from https://github.com/opensearch-project/dashboards-maps/issues/458#issuecomment-1817272275, this PR:
1. Removes the redundant padding on tooltip
2. Changes the scroll bar to automatically display on tooltip

### Test
Before:
<img width="462" alt="image" src="https://github.com/opensearch-project/dashboards-maps/assets/90288540/f235fb58-0a28-4175-8f0b-808820a2f8af">

After:
<img width="379" alt="image" src="https://github.com/opensearch-project/dashboards-maps/assets/90288540/cbd71e12-521f-4413-b193-5ccdda8c9604">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
