### PR TITLE
Update dependencies to align with other plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 ### Maintenance
 * Fix broken build and failing tests [#572](https://github.com/opensearch-project/dashboards-maps/pull/572)
+* Update dependencies to align with other plugins [#575](https://github.com/opensearch-project/dashboards-maps/pull/575)
 ### Refactoring

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "wellknown": "^0.5.0"
   },
   "devDependencies": {
-    "@types/react-test-renderer": "^18.0.0",
-    "cypress": "^13.1.0",
+    "@types/react-test-renderer": "^18.0.7",
+    "cypress": "^13.6.3",
     "cypress-multi-reporters": "^1.5.0",
     "prettier": "^2.1.1"
   }


### PR DESCRIPTION
### Description
Updates cypress and react-test-renderer dependencies to latest versions in order to align with other dashboards plugins

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/571

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
