### PR TITLE
Add data source reference id in data layer search request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+* Add data source reference id in data layer search request ([#623](https://github.com/opensearch-project/dashboards-maps/pull/623))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/public/model/layerRenderController.ts
+++ b/public/model/layerRenderController.ts
@@ -76,6 +76,7 @@ export const prepareDataLayerSource = (
           ...(timeFilters ? [timeFilters] : []),
         ]);
       }
+      const dataSourceId = indexPattern?.dataSourceRef?.id;
       const request = {
         params: {
           index: indexPatternRefName,
@@ -85,6 +86,7 @@ export const prepareDataLayerSource = (
             query: mergedQuery,
           },
         },
+        ...(!!dataSourceId && { dataSourceId }),
       };
 
       const search$ = data.search.search(request).subscribe({


### PR DESCRIPTION
### Description
Add data source reference id in data layer search request to avoid potential search error if there is no local cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
