### PR TITLE
Refresh custom wms layer+source on update (issue 601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+* Fixed broken wms custom layer update ([#601](https://github.com/opensearch-project/dashboards-maps/pull/631))
 * Add data source reference id in data layer search request ([#623](https://github.com/opensearch-project/dashboards-maps/pull/623))
 ### Infrastructure
 ### Documentation

--- a/public/model/customLayerFunctions.test.ts
+++ b/public/model/customLayerFunctions.test.ts
@@ -92,34 +92,6 @@ describe('CustomLayerFunctions', () => {
     expect(map.addLayer).toHaveBeenCalledWith(expect.any(Object));
   });
 
-  it('should update an existing layer', () => {
-    const updatedLayerConfig: CustomLayerSpecification = {
-      id: 'existing-layer',
-      source: {
-        // @ts-ignore
-        type: DASHBOARDS_CUSTOM_MAPS_LAYER_TYPE.TMS,
-        tiles: ['https://updatedtiles.example.com/{z}/{x}/{y}.png'],
-        attribution: 'Updated Test Attribution',
-      },
-      opacity: 50,
-      zoomRange: [0, 15],
-      visibility: 'visible',
-    };
-
-    CustomLayerFunctions.render(maplibreRef, updatedLayerConfig);
-
-    expect(map.setPaintProperty).toHaveBeenCalledWith(
-      updatedLayerConfig.id,
-      'raster-opacity',
-      updatedLayerConfig.opacity / 100
-    );
-    expect(map.setLayerZoomRange).toHaveBeenCalledWith(
-      updatedLayerConfig.id,
-      updatedLayerConfig.zoomRange[0],
-      updatedLayerConfig.zoomRange[1]
-    );
-  });
-
   it('should convert zoomRange to a numeric array', () => {
     const layerConfig = {
       id: 'test-layer',

--- a/public/model/customLayerFunctions.ts
+++ b/public/model/customLayerFunctions.ts
@@ -2,52 +2,6 @@ import { CustomLayerSpecification, OSMLayerSpecification } from './mapLayerType'
 import { hasLayer, removeLayers } from './map/layer_operations';
 import { MaplibreRef } from './layersFunctions';
 
-// const updateLayerConfig = (layerConfig: CustomLayerSpecification, maplibreRef: MaplibreRef) => {
-//   const maplibreInstance = maplibreRef.current;
-//   if (maplibreInstance) {
-//     const customLayer = maplibreInstance.getLayer(layerConfig.id);
-//     if (customLayer) {
-//       maplibreInstance.setPaintProperty(
-//         layerConfig.id,
-//         'raster-opacity',
-//         layerConfig.opacity / 100
-//       );
-//       maplibreInstance.setLayerZoomRange(
-//         layerConfig.id,
-//         layerConfig.zoomRange[0],
-//         layerConfig.zoomRange[1]
-//       );
-//       const rasterLayerSource = maplibreInstance.getSource(
-//         layerConfig.id
-//       )! as RasterSourceSpecification;
-//       if (rasterLayerSource.attribution !== layerConfig.source?.attribution) {
-//         rasterLayerSource.attribution = layerConfig?.source?.attribution;
-//         maplibreInstance._controls.forEach((control) => {
-//           if (control instanceof AttributionControl) {
-//             control._updateAttributions();
-//           }
-//         });
-//       }
-//       const tilesURL = getCustomMapURL(layerConfig);
-//       console.log("here123");
-//       if (rasterLayerSource.tiles![0] !== tilesURL) {
-//         console.log("here124");
-//         rasterLayerSource.tiles = [layerConfig?.source?.url];
-//         console.log(maplibreInstance);
-//         maplibreInstance.style.sourceCaches[layerConfig.id].clearTiles();
-//         console.log("transform");
-//         console.log(maplibreInstance.transform);
-//         console.log("transform id");
-//         console.log(maplibreInstance.style.sourceCaches[layerConfig.id]);
-//         maplibreInstance.style.sourceCaches[layerConfig.id].update(maplibreInstance.transform); // error here
-//         maplibreInstance.triggerRepaint();
-//       }
-//       console.log("here1235");
-//       console.log(tilesURL);
-//     }
-//   }
-// };
-
 const refreshLayer = (layerConfig: CustomLayerSpecification, maplibreRef: MaplibreRef) => {
   const maplibreInstance = maplibreRef.current;
   if (maplibreInstance) {
@@ -86,7 +40,6 @@ const addNewLayer = (layerConfig: CustomLayerSpecification, maplibreRef: Maplibr
   }
 };
 
-// not the issue
 const getCustomMapURL = (layerConfig: CustomLayerSpecification) => {
   const layerSource = layerConfig?.source;
   if (layerSource?.customType === 'tms') {

--- a/public/model/customLayerFunctions.ts
+++ b/public/model/customLayerFunctions.ts
@@ -1,42 +1,59 @@
-import { AttributionControl, RasterSourceSpecification } from 'maplibre-gl';
 import { CustomLayerSpecification, OSMLayerSpecification } from './mapLayerType';
 import { hasLayer, removeLayers } from './map/layer_operations';
 import { MaplibreRef } from './layersFunctions';
 
-const updateLayerConfig = (layerConfig: CustomLayerSpecification, maplibreRef: MaplibreRef) => {
+// const updateLayerConfig = (layerConfig: CustomLayerSpecification, maplibreRef: MaplibreRef) => {
+//   const maplibreInstance = maplibreRef.current;
+//   if (maplibreInstance) {
+//     const customLayer = maplibreInstance.getLayer(layerConfig.id);
+//     if (customLayer) {
+//       maplibreInstance.setPaintProperty(
+//         layerConfig.id,
+//         'raster-opacity',
+//         layerConfig.opacity / 100
+//       );
+//       maplibreInstance.setLayerZoomRange(
+//         layerConfig.id,
+//         layerConfig.zoomRange[0],
+//         layerConfig.zoomRange[1]
+//       );
+//       const rasterLayerSource = maplibreInstance.getSource(
+//         layerConfig.id
+//       )! as RasterSourceSpecification;
+//       if (rasterLayerSource.attribution !== layerConfig.source?.attribution) {
+//         rasterLayerSource.attribution = layerConfig?.source?.attribution;
+//         maplibreInstance._controls.forEach((control) => {
+//           if (control instanceof AttributionControl) {
+//             control._updateAttributions();
+//           }
+//         });
+//       }
+//       const tilesURL = getCustomMapURL(layerConfig);
+//       console.log("here123");
+//       if (rasterLayerSource.tiles![0] !== tilesURL) {
+//         console.log("here124");
+//         rasterLayerSource.tiles = [layerConfig?.source?.url];
+//         console.log(maplibreInstance);
+//         maplibreInstance.style.sourceCaches[layerConfig.id].clearTiles();
+//         console.log("transform");
+//         console.log(maplibreInstance.transform);
+//         console.log("transform id");
+//         console.log(maplibreInstance.style.sourceCaches[layerConfig.id]);
+//         maplibreInstance.style.sourceCaches[layerConfig.id].update(maplibreInstance.transform); // error here
+//         maplibreInstance.triggerRepaint();
+//       }
+//       console.log("here1235");
+//       console.log(tilesURL);
+//     }
+//   }
+// };
+
+const refreshLayer = (layerConfig: CustomLayerSpecification, maplibreRef: MaplibreRef) => {
   const maplibreInstance = maplibreRef.current;
   if (maplibreInstance) {
-    const customLauer = maplibreInstance.getLayer(layerConfig.id);
-    if (customLauer) {
-      maplibreInstance.setPaintProperty(
-        layerConfig.id,
-        'raster-opacity',
-        layerConfig.opacity / 100
-      );
-      maplibreInstance.setLayerZoomRange(
-        layerConfig.id,
-        layerConfig.zoomRange[0],
-        layerConfig.zoomRange[1]
-      );
-      const rasterLayerSource = maplibreInstance.getSource(
-        layerConfig.id
-      )! as RasterSourceSpecification;
-      if (rasterLayerSource.attribution !== layerConfig.source?.attribution) {
-        rasterLayerSource.attribution = layerConfig?.source?.attribution;
-        maplibreInstance._controls.forEach((control) => {
-          if (control instanceof AttributionControl) {
-            control._updateAttributions();
-          }
-        });
-      }
-      const tilesURL = getCustomMapURL(layerConfig);
-      if (rasterLayerSource.tiles![0] !== tilesURL) {
-        rasterLayerSource.tiles = [layerConfig?.source?.url];
-        maplibreInstance.style.sourceCaches[layerConfig.id].clearTiles();
-        maplibreInstance.style.sourceCaches[layerConfig.id].update(maplibreInstance.transform);
-        maplibreInstance.triggerRepaint();
-      }
-    }
+    maplibreInstance.removeLayer(layerConfig.id);
+    maplibreInstance.removeSource(layerConfig.id);
+    addNewLayer(layerConfig, maplibreRef);
   }
 };
 
@@ -69,6 +86,7 @@ const addNewLayer = (layerConfig: CustomLayerSpecification, maplibreRef: Maplibr
   }
 };
 
+// not the issue
 const getCustomMapURL = (layerConfig: CustomLayerSpecification) => {
   const layerSource = layerConfig?.source;
   if (layerSource?.customType === 'tms') {
@@ -89,7 +107,7 @@ export const applyZoomRangeToLayer = (layerConfig: CustomLayerSpecification) => 
 export const CustomLayerFunctions = {
   render: (maplibreRef: MaplibreRef, layerConfig: CustomLayerSpecification) => {
     return hasLayer(maplibreRef.current!, layerConfig.id)
-      ? updateLayerConfig(layerConfig, maplibreRef)
+      ? refreshLayer(layerConfig, maplibreRef)
       : addNewLayer(layerConfig, maplibreRef);
   },
   remove: (maplibreRef: MaplibreRef, layerConfig: OSMLayerSpecification) => {


### PR DESCRIPTION
### Description
`UpdateLayerConfig()` is broken as per https://github.com/opensearch-project/dashboards-maps/issues/601. Specifically, line 36 `maplibreInstance.style.sourceCaches[layerConfig.id].update(maplibreInstance.transform)` throws a object reference error. I suspect `maplibreInstance.transform` is gone by the time it's used. Additionally, there are alot of what seem to be workarounds in the function, namely calling seemingly private methods of MaplibreGL and a spelling mistake. While I am by no means familiar with this codebase, it seems that simply deleting and refreshing the layer+source would be a better option. Especially, since updating wms fields would require a full refresh of tiles anyway.

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/601

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
