### PR TITLE
Use smaller and compressed varients of buttons and form components 

### DIFF
--- a/public/components/__snapshots__/vector_upload_options.test.tsx.snap
+++ b/public/components/__snapshots__/vector_upload_options.test.tsx.snap
@@ -39,14 +39,14 @@ Object {
               />
               <div
                 aria-label="form-row-for-file-picker"
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="generated-id-row"
               >
                 <div
                   class="euiFormRow__fieldWrapper"
                 >
                   <div
-                    class="euiFilePicker euiFilePicker--large"
+                    class="euiFilePicker euiFilePicker--large euiFilePicker--compressed"
                   >
                     <div
                       class="euiFilePicker__wrap"
@@ -135,14 +135,14 @@ Object {
                 class="euiSpacer euiSpacer--m"
               />
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
                     aria-label="map-name-text-field"
-                    class="euiFieldText"
+                    class="euiFieldText euiFieldText--compressed"
                     data-test-subj="customIndex"
                     data-testid="customIndex"
                     id="customIndex"
@@ -206,7 +206,7 @@ Object {
               >
                 <button
                   aria-label="import-file-button"
-                  class="euiButton euiButton--primary euiButton--fill"
+                  class="euiButton euiButton--primary euiButton--small euiButton--fill"
                   id="submitButton"
                   type="button"
                 >
@@ -262,14 +262,14 @@ Object {
             />
             <div
               aria-label="form-row-for-file-picker"
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="generated-id-row"
             >
               <div
                 class="euiFormRow__fieldWrapper"
               >
                 <div
-                  class="euiFilePicker euiFilePicker--large"
+                  class="euiFilePicker euiFilePicker--large euiFilePicker--compressed"
                 >
                   <div
                     class="euiFilePicker__wrap"
@@ -358,14 +358,14 @@ Object {
               class="euiSpacer euiSpacer--m"
             />
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-label="map-name-text-field"
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   data-test-subj="customIndex"
                   data-testid="customIndex"
                   id="customIndex"
@@ -429,7 +429,7 @@ Object {
             >
               <button
                 aria-label="import-file-button"
-                class="euiButton euiButton--primary euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small euiButton--fill"
                 id="submitButton"
                 type="button"
               >

--- a/public/components/filter_bar/__snapshots__/filter_editor.test.tsx.snap
+++ b/public/components/filter_bar/__snapshots__/filter_editor.test.tsx.snap
@@ -16,9 +16,9 @@ exports[`renders one filter inside filter bar 1`] = `
     className="globalFilterItem__editorForm"
   >
     <EuiForm>
-      <EuiFormRow
+      <EuiCompressedFormRow
         describedByIds={Array []}
-        display="row"
+        display="rowCompressed"
         fullWidth={true}
         hasChildLabel={true}
         hasEmptyLabelSpace={false}
@@ -33,26 +33,26 @@ exports[`renders one filter inside filter bar 1`] = `
           value="\\"{}\\""
           width="100%"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <div>
         <EuiSpacer
           size="m"
         />
-        <EuiFormRow
+        <EuiCompressedFormRow
           describedByIds={Array []}
-          display="row"
+          display="rowCompressed"
           fullWidth={true}
           hasChildLabel={true}
           hasEmptyLabelSpace={false}
           label="Custom label"
           labelType="label"
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             fullWidth={true}
             onChange={[Function]}
             value="mylabel"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </div>
       <EuiSpacer
         size="m"
@@ -65,25 +65,25 @@ exports[`renders one filter inside filter bar 1`] = `
         <EuiFlexItem
           grow={false}
         >
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="saveFilter"
             fill={true}
             isDisabled={false}
             onClick={[Function]}
           >
             Save
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem
           grow={false}
         >
-          <EuiButtonEmpty
+          <EuiSmallButtonEmpty
             data-test-subj="cancelSaveFilter"
             flush="right"
             onClick={[MockFunction]}
           >
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem />
       </EuiFlexGroup>

--- a/public/components/filter_bar/filter_editor.tsx
+++ b/public/components/filter_bar/filter_editor.tsx
@@ -7,7 +7,7 @@ import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiCodeEditor,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -74,7 +74,7 @@ export const FilterEditor = ({ content, label, onSubmit, onCancel }: Props) => {
                 defaultMessage: 'Custom label',
               })}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 fullWidth={true}
                 value={filterLabel}
                 onChange={(event) => setFilterLabel(event.target.value)}

--- a/public/components/filter_bar/filter_editor.tsx
+++ b/public/components/filter_bar/filter_editor.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPopoverTitle,
   EuiSpacer,
 } from '@elastic/eui';
@@ -39,7 +39,7 @@ export const FilterEditor = ({ content, label, onSubmit, onCancel }: Props) => {
 
   const renderEditor = () => {
     return (
-      <EuiFormRow
+      <EuiCompressedFormRow
         label={i18n.translate('maps.filter.filterEditor.parameters', {
           defaultMessage: 'Spatial filter parameters',
         })}
@@ -52,7 +52,7 @@ export const FilterEditor = ({ content, label, onSubmit, onCancel }: Props) => {
           width="100%"
           height="250px"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
   return (
@@ -68,7 +68,7 @@ export const FilterEditor = ({ content, label, onSubmit, onCancel }: Props) => {
           {renderEditor()}
           <div>
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               fullWidth={true}
               label={i18n.translate('maps.filter.filterEditor.createCustomLabelInputLabel', {
                 defaultMessage: 'Custom label',
@@ -79,7 +79,7 @@ export const FilterEditor = ({ content, label, onSubmit, onCancel }: Props) => {
                 value={filterLabel}
                 onChange={(event) => setFilterLabel(event.target.value)}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </div>
           <EuiSpacer size="m" />
           <EuiFlexGroup direction="rowReverse" alignItems="center" responsive={false}>

--- a/public/components/filter_bar/filter_editor.tsx
+++ b/public/components/filter_bar/filter_editor.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCodeEditor,
   EuiFieldText,
@@ -84,14 +84,14 @@ export const FilterEditor = ({ content, label, onSubmit, onCancel }: Props) => {
           <EuiSpacer size="m" />
           <EuiFlexGroup direction="rowReverse" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 fill
                 onClick={() => onSubmit(filterContent, filterLabel)}
                 isDisabled={!isFilterValid(filterContent)}
                 data-test-subj="saveFilter"
               >
                 {'Save'}
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButtonEmpty flush="right" onClick={onCancel} data-test-subj="cancelSaveFilter">

--- a/public/components/filter_bar/filter_editor.tsx
+++ b/public/components/filter_bar/filter_editor.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCodeEditor,
   EuiFieldText,
   EuiFlexGroup,
@@ -94,9 +94,9 @@ export const FilterEditor = ({ content, label, onSubmit, onCancel }: Props) => {
               </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty flush="right" onClick={onCancel} data-test-subj="cancelSaveFilter">
+              <EuiSmallButtonEmpty flush="right" onClick={onCancel} data-test-subj="cancelSaveFilter">
                 {'Cancel'}
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem />
           </EuiFlexGroup>

--- a/public/components/filter_bar/filter_options.tsx
+++ b/public/components/filter_bar/filter_options.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButtonIcon, EuiContextMenu, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
+import { EuiSmallButtonIcon, EuiContextMenu, EuiPopover, EuiPopoverTitle } from '@elastic/eui';
 import React, { useState } from 'react';
 import { i18n } from '@osd/i18n';
 
@@ -99,7 +99,7 @@ export const FilterOptions = ({
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       button={
-        <EuiButtonIcon
+        <EuiSmallButtonIcon
           onClick={togglePopover}
           iconType="filter"
           aria-label={i18n.translate('maps.filter.options.changeAllFiltersButtonLabel', {

--- a/public/components/layer_config/custom_map_config/custom_map_source.tsx
+++ b/public/components/layer_config/custom_map_config/custom_map_source.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiSpacer, EuiPanel, EuiForm, EuiFieldText, EuiSelect, EuiCompressedFormRow } from '@elastic/eui';
+import { EuiSpacer, EuiPanel, EuiForm, EuiCompressedFieldText, EuiSelect, EuiCompressedFormRow } from '@elastic/eui';
 import { CustomLayerSpecification } from '../../../model/mapLayerType';
 
 interface Props {
@@ -198,7 +198,7 @@ export const CustomMapSource = ({
               error={isInvalidURL(customMapURL) ? 'Invalid URL' : undefined}
               fullWidth={true}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 placeholder="https://www.example.com/tiles/{z}/{x}/{y}.png"
                 value={customMapURL}
                 onChange={onChangeCustomMapURL}
@@ -212,7 +212,7 @@ export const CustomMapSource = ({
               helpText="The attribution for the TMS layer, displayed in the lower-right corner of the map."
               fullWidth={true}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 value={customMapAttribution}
                 onChange={onChangeCustomMapAttribution}
                 fullWidth={true}
@@ -229,7 +229,7 @@ export const CustomMapSource = ({
               error={isInvalidURL(customMapURL) ? 'Invalid URL' : undefined}
               fullWidth={true}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 placeholder="https://www.example.com/wms/dataset"
                 value={customMapURL}
                 onChange={onChangeCustomMapURL}
@@ -243,11 +243,11 @@ export const CustomMapSource = ({
               helpText="The names of the layers to include in the map image. For more than one name, use a comma-separated list."
               fullWidth={true}
             >
-              <EuiFieldText value={WMSLayers} onChange={onChangeWMSLayers} fullWidth={true} />
+              <EuiCompressedFieldText value={WMSLayers} onChange={onChangeWMSLayers} fullWidth={true} />
             </EuiCompressedFormRow>
             <EuiSpacer size="m" />
             <EuiCompressedFormRow label="WMS version*" fullWidth={true}>
-              <EuiFieldText value={WMSVersion} onChange={onChangeWMSVersion} fullWidth={true} />
+              <EuiCompressedFieldText value={WMSVersion} onChange={onChangeWMSVersion} fullWidth={true} />
             </EuiCompressedFormRow>
             <EuiSpacer size="m" />
             <EuiCompressedFormRow
@@ -255,7 +255,7 @@ export const CustomMapSource = ({
               helpText="The format of the map image to return. The most common formats are 'image/png' and 'image/jpeg'."
               fullWidth={true}
             >
-              <EuiFieldText value={WMSFormat} onChange={onChangeWMSFormat} fullWidth={true} />
+              <EuiCompressedFieldText value={WMSFormat} onChange={onChangeWMSFormat} fullWidth={true} />
             </EuiCompressedFormRow>
             <EuiSpacer size="m" />
             <EuiCompressedFormRow
@@ -263,7 +263,7 @@ export const CustomMapSource = ({
               helpText="The coordinate reference system (CRS) to use for the map image."
               fullWidth={true}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 value={WMSCoordinateSystem}
                 onChange={onChangeWMSCoordinateSystem}
                 fullWidth={true}
@@ -275,7 +275,7 @@ export const CustomMapSource = ({
               helpText="The bounding box of the region to include in the map image."
               fullWidth={true}
             >
-              <EuiFieldText value={WMSBbox} onChange={onChangeWMSBbox} fullWidth={true} />
+              <EuiCompressedFieldText value={WMSBbox} onChange={onChangeWMSBbox} fullWidth={true} />
             </EuiCompressedFormRow>
             <EuiSpacer size="m" />
             <EuiCompressedFormRow
@@ -283,7 +283,7 @@ export const CustomMapSource = ({
               helpText="The attribution for this WMS layer, displayed at right-bottom map."
               fullWidth={true}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 value={customMapAttribution}
                 onChange={onChangeCustomMapAttribution}
                 fullWidth={true}
@@ -295,7 +295,7 @@ export const CustomMapSource = ({
               helpText="The styles to be used for each of the layers in the map image."
               fullWidth={true}
             >
-              <EuiFieldText value={WMSStyles} onChange={onChangeWMSStyles} fullWidth={true} />
+              <EuiCompressedFieldText value={WMSStyles} onChange={onChangeWMSStyles} fullWidth={true} />
             </EuiCompressedFormRow>
           </EuiForm>
         )}

--- a/public/components/layer_config/custom_map_config/custom_map_source.tsx
+++ b/public/components/layer_config/custom_map_config/custom_map_source.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiSpacer, EuiPanel, EuiForm, EuiCompressedFieldText, EuiSelect, EuiCompressedFormRow } from '@elastic/eui';
+import { EuiSpacer, EuiPanel, EuiForm, EuiCompressedFieldText, EuiCompressedSelect, EuiCompressedFormRow } from '@elastic/eui';
 import { CustomLayerSpecification } from '../../../model/mapLayerType';
 
 interface Props {
@@ -180,7 +180,7 @@ export const CustomMapSource = ({
       <EuiPanel paddingSize="s">
         <EuiForm>
           <EuiCompressedFormRow label="Custom type" helpText="Choose custom map type." fullWidth={true}>
-            <EuiSelect
+            <EuiCompressedSelect
               options={customMapTypeOptions}
               value={customType}
               onChange={onChangeCustomType}

--- a/public/components/layer_config/custom_map_config/custom_map_source.tsx
+++ b/public/components/layer_config/custom_map_config/custom_map_source.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiSpacer, EuiPanel, EuiForm, EuiFieldText, EuiSelect, EuiFormRow } from '@elastic/eui';
+import { EuiSpacer, EuiPanel, EuiForm, EuiFieldText, EuiSelect, EuiCompressedFormRow } from '@elastic/eui';
 import { CustomLayerSpecification } from '../../../model/mapLayerType';
 
 interface Props {
@@ -179,19 +179,19 @@ export const CustomMapSource = ({
     <div>
       <EuiPanel paddingSize="s">
         <EuiForm>
-          <EuiFormRow label="Custom type" helpText="Choose custom map type." fullWidth={true}>
+          <EuiCompressedFormRow label="Custom type" helpText="Choose custom map type." fullWidth={true}>
             <EuiSelect
               options={customMapTypeOptions}
               value={customType}
               onChange={onChangeCustomType}
               fullWidth={true}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiForm>
         <EuiSpacer size="m" />
         {selectedLayerConfig.source.customType === 'tms' && (
           <EuiForm>
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="TMS URL*"
               helpText="Raster tile map service URL."
               isInvalid={isInvalidURL(customMapURL)}
@@ -205,9 +205,9 @@ export const CustomMapSource = ({
                 isInvalid={isInvalidURL(customMapURL)}
                 fullWidth={true}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="TMS attribution"
               helpText="The attribution for the TMS layer, displayed in the lower-right corner of the map."
               fullWidth={true}
@@ -217,12 +217,12 @@ export const CustomMapSource = ({
                 onChange={onChangeCustomMapAttribution}
                 fullWidth={true}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         )}
         {selectedLayerConfig.source.customType === 'wms' && (
           <EuiForm>
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="WMS URL*"
               helpText="Web map service URL"
               isInvalid={isInvalidURL(customMapURL)}
@@ -236,29 +236,29 @@ export const CustomMapSource = ({
                 isInvalid={isInvalidURL(customMapURL)}
                 fullWidth={true}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="WMS layers*"
               helpText="The names of the layers to include in the map image. For more than one name, use a comma-separated list."
               fullWidth={true}
             >
               <EuiFieldText value={WMSLayers} onChange={onChangeWMSLayers} fullWidth={true} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="m" />
-            <EuiFormRow label="WMS version*" fullWidth={true}>
+            <EuiCompressedFormRow label="WMS version*" fullWidth={true}>
               <EuiFieldText value={WMSVersion} onChange={onChangeWMSVersion} fullWidth={true} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="WMS format*"
               helpText="The format of the map image to return. The most common formats are 'image/png' and 'image/jpeg'."
               fullWidth={true}
             >
               <EuiFieldText value={WMSFormat} onChange={onChangeWMSFormat} fullWidth={true} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="WMS CRS"
               helpText="The coordinate reference system (CRS) to use for the map image."
               fullWidth={true}
@@ -268,17 +268,17 @@ export const CustomMapSource = ({
                 onChange={onChangeWMSCoordinateSystem}
                 fullWidth={true}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="WMS bbox"
               helpText="The bounding box of the region to include in the map image."
               fullWidth={true}
             >
               <EuiFieldText value={WMSBbox} onChange={onChangeWMSBbox} fullWidth={true} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="WMS attribution"
               helpText="The attribution for this WMS layer, displayed at right-bottom map."
               fullWidth={true}
@@ -288,15 +288,15 @@ export const CustomMapSource = ({
                 onChange={onChangeCustomMapAttribution}
                 fullWidth={true}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             <EuiSpacer size="m" />
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="WMS styles"
               helpText="The styles to be used for each of the layers in the map image."
               fullWidth={true}
             >
               <EuiFieldText value={WMSStyles} onChange={onChangeWMSStyles} fullWidth={true} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         )}
         <EuiSpacer size="s" />

--- a/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -15,7 +15,7 @@ import {
   EuiSpacer,
   EuiPanel,
   EuiForm,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiCompressedCheckbox,
   EuiCheckbox,
   EuiCompressedFormRow,
@@ -415,7 +415,7 @@ export const DocumentLayerSource = ({
                   />
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  <EuiSwitch
+                  <EuiCompressedSwitch
                     label={i18n.translate('documentLayer.displayTooltipsOnHover', {
                       defaultMessage: 'Display tooltips on hover',
                     })}

--- a/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -9,7 +9,7 @@ import {
   EuiFlexItem,
   EuiFormLabel,
   EuiFlexGrid,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFormErrorText,
   EuiCollapsibleNavGroup,
   EuiSpacer,
@@ -315,7 +315,7 @@ export const DocumentLayerSource = ({
               <EuiFlexItem>
                 <EuiFormLabel>Number of documents</EuiFormLabel>
                 <EuiSpacer size="xs" />
-                <EuiFieldNumber
+                <EuiCompressedFieldNumber
                   placeholder="Number of documents"
                   value={selectedLayerConfig.source.documentRequestNumber}
                   onChange={onDocumentRequestNumberChange}

--- a/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -16,6 +16,7 @@ import {
   EuiPanel,
   EuiForm,
   EuiSwitch,
+  EuiCompressedCheckbox,
   EuiCheckbox,
   EuiCompressedFormRow,
 } from '@elastic/eui';
@@ -384,7 +385,7 @@ export const DocumentLayerSource = ({
         >
           <EuiFlexGrid columns={1}>
             <EuiFlexItem>
-              <EuiCheckbox
+              <EuiCompressedCheckbox
                 id="enable-tooltip"
                 label={i18n.translate('documentLayer.enableTooltips', {
                   defaultMessage: 'Enable tooltips',

--- a/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -5,7 +5,7 @@
 
 import React, { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiFlexItem,
   EuiFormLabel,
   EuiFlexGrid,
@@ -295,7 +295,7 @@ export const DocumentLayerSource = ({
                   data-test-subj={'geoFieldSelect'}
                   fullWidth={true}
                 >
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     options={getFieldsOptions(indexPattern, acceptedFieldTypes)}
                     selectedOptions={formatFieldStringToComboBox(selectedField?.displayName)}
                     singleSelection={true}
@@ -399,7 +399,7 @@ export const DocumentLayerSource = ({
                 <EuiFlexItem>
                   <EuiFormLabel>Tooltip fields</EuiFormLabel>
                   <EuiSpacer size="xs" />
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     options={getFieldsOptions(indexPattern)}
                     selectedOptions={formatFieldsStringToComboBox(
                       selectedLayerConfig.source.tooltipFields

--- a/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -17,7 +17,7 @@ import {
   EuiForm,
   EuiSwitch,
   EuiCheckbox,
-  EuiFormRow,
+  EuiCompressedFormRow,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
@@ -263,7 +263,7 @@ export const DocumentLayerSource = ({
           <EuiForm>
             <EuiFlexGrid columns={1}>
               <EuiFlexItem>
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label="Index pattern"
                   isInvalid={!indexPattern}
                   error={errorsMap.datasource}
@@ -284,10 +284,10 @@ export const DocumentLayerSource = ({
                     data-test-subj={'indexPatternSelect'}
                     fullWidth={true}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label="Geospatial field"
                   isInvalid={!selectedField}
                   error={errorsMap.geoFields}
@@ -310,7 +310,7 @@ export const DocumentLayerSource = ({
                     fullWidth={true}
                     isClearable={false}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFormLabel>Number of documents</EuiFormLabel>
@@ -352,7 +352,7 @@ export const DocumentLayerSource = ({
             onFiltersUpdated={onFiltersUpdated}
           />
           <EuiSpacer />
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiCheckbox
               id={`${selectedLayerConfig.id}-bounding-box-filter`}
               label={'Only request data around map extent'}
@@ -360,8 +360,8 @@ export const DocumentLayerSource = ({
               onChange={onToggleGeoBoundingBox}
               compressed
             />
-          </EuiFormRow>
-          <EuiFormRow>
+          </EuiCompressedFormRow>
+          <EuiCompressedFormRow>
             <EuiCheckbox
               id={`${selectedLayerConfig.id}-apply-global-filter`}
               label={i18n.translate('documentLayer.applyGlobalFilters', {
@@ -371,7 +371,7 @@ export const DocumentLayerSource = ({
               onChange={onApplyGlobalFilters}
               compressed
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiCollapsibleNavGroup>
       </EuiPanel>
       <EuiSpacer size="m" />

--- a/public/components/layer_config/documents_config/style/color_picker.tsx
+++ b/public/components/layer_config/documents_config/style/color_picker.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { memo, useEffect } from 'react';
-import { EuiColorPicker, EuiFormRow, useColorPickerState } from '@elastic/eui';
+import { EuiColorPicker, EuiCompressedFormRow, useColorPickerState } from '@elastic/eui';
 
 export interface ColorPickerProps {
   originColor: string;
@@ -38,7 +38,7 @@ export const ColorPicker = memo(
     }, [selectedLayerConfigId]);
 
     return (
-      <EuiFormRow label={label} fullWidth={true} isInvalid={!!colorErrors} error={colorErrors}>
+      <EuiCompressedFormRow label={label} fullWidth={true} isInvalid={!!colorErrors} error={colorErrors}>
         <EuiColorPicker
           color={color}
           onChange={setColor}
@@ -46,7 +46,7 @@ export const ColorPicker = memo(
           fullWidth={true}
           data-test-subj={label}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   }
 );

--- a/public/components/layer_config/documents_config/style/document_layer_style.tsx
+++ b/public/components/layer_config/documents_config/style/document_layer_style.tsx
@@ -10,7 +10,7 @@ import {
   EuiSpacer,
   EuiButtonGroup,
   EuiPanel,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiForm,
   EuiCollapsibleNavGroup,
 } from '@elastic/eui';
@@ -123,7 +123,7 @@ export const DocumentLayerStyle = ({
     max,
   }: WidthSelectorProps) => {
     return (
-      <EuiFormRow
+      <EuiCompressedFormRow
         label={label}
         fullWidth={true}
         isInvalid={hasInvalid}
@@ -141,7 +141,7 @@ export const DocumentLayerStyle = ({
           min={min}
           max={max}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
 

--- a/public/components/layer_config/documents_config/style/document_layer_style.tsx
+++ b/public/components/layer_config/documents_config/style/document_layer_style.tsx
@@ -5,7 +5,7 @@
 
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import {
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFormLabel,
   EuiSpacer,
   EuiButtonGroup,
@@ -131,7 +131,7 @@ export const DocumentLayerStyle = ({
           defaultMessage: `must be between ${min} and ${max}`,
         })}
       >
-        <EuiFieldNumber
+        <EuiCompressedFieldNumber
           placeholder="Select thickness"
           value={size}
           onChange={onWidthChange}

--- a/public/components/layer_config/documents_config/style/label_config.test.tsx
+++ b/public/components/layer_config/documents_config/style/label_config.test.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { LabelConfig } from './label_config';
-import { EuiCheckbox, EuiFormLabel } from '@elastic/eui';
 import {
+  EuiCompressedCheckbox,
+  EuiCompressedComboBox,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
+  EuiCompressedSelect,
+  EuiFormLabel,
+} from '@elastic/eui';
+import {
+  DASHBOARDS_MAPS_LAYER_TYPE,
   DOCUMENTS_LARGE_LABEL_BORDER_WIDTH,
   DOCUMENTS_MEDIUM_LABEL_BORDER_WIDTH,
   DOCUMENTS_NONE_LABEL_BORDER_WIDTH,
@@ -20,7 +28,7 @@ describe('LabelConfig', () => {
   const mockLayerConfig: DocumentLayerSpecification = {
     name: 'My Document Layer',
     id: 'document-layer-1',
-    type: 'documents',
+    type: DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS,
     description: 'A layer of documents',
     zoomRange: [5, 18],
     opacity: 0.8,
@@ -81,13 +89,13 @@ describe('LabelConfig', () => {
   });
 
   it('should render EuiCheckbox with correct props', () => {
-    const checkbox = wrapper.find(EuiCheckbox);
+    const checkbox = wrapper.find(EuiCompressedCheckbox);
     expect(checkbox.prop('label')).toEqual('Add label');
     expect(checkbox.prop('checked')).toEqual(true);
   });
 
   it('should call setSelectedLayerConfig with updated config when onChangeShowLabel is called', () => {
-    const checkbox = wrapper.find(EuiCheckbox);
+    const checkbox = wrapper.find(EuiCompressedCheckbox);
     checkbox.simulate('change', { target: { checked: false } });
     expect(setSelectedLayerConfigMock).toHaveBeenCalledWith({
       ...mockLayerConfig,
@@ -113,12 +121,12 @@ describe('LabelConfig', () => {
       },
     };
     wrapper.setProps({ selectedLayerConfig: newSelectedLayerConfig });
-    const checkbox = wrapper.find(EuiCheckbox);
+    const checkbox = wrapper.find(EuiCompressedCheckbox);
     expect(checkbox.prop('checked')).toEqual(false);
   });
 
   it('should call setSelectedLayerConfig with updated config when onChangeLabelTextType is called', () => {
-    const select = wrapper.find('EuiSelect').at(0);
+    const select = wrapper.find(EuiCompressedSelect).at(0);
     select.simulate('change', { target: { value: 'by_field' } });
     expect(setSelectedLayerConfigMock).toHaveBeenCalledWith({
       ...mockLayerConfig,
@@ -133,7 +141,7 @@ describe('LabelConfig', () => {
   });
 
   it('should render EuiFieldText with correct props when labelTextType is "fixed"', () => {
-    const fieldText = wrapper.find('EuiFieldText');
+    const fieldText = wrapper.find(EuiCompressedFieldText);
     expect(fieldText.prop('value')).toEqual('My Label');
   });
 
@@ -150,12 +158,12 @@ describe('LabelConfig', () => {
       },
     };
     wrapper.setProps({ selectedLayerConfig: newSelectedLayerConfig });
-    const fieldText = wrapper.find('EuiComboBox');
+    const fieldText = wrapper.find(EuiCompressedComboBox);
     expect(fieldText.prop('selectedOptions')).toEqual([{ label: 'Field 1' }]);
   });
 
   it('should call setSelectedLayerConfig with updated config when onStaticLabelChange is called', () => {
-    const fieldText = wrapper.find('EuiFieldText');
+    const fieldText = wrapper.find(EuiCompressedFieldText);
     fieldText.simulate('change', { target: { value: 'new label' } });
     expect(setSelectedLayerConfigMock).toHaveBeenCalledWith({
       ...mockLayerConfig,
@@ -170,14 +178,14 @@ describe('LabelConfig', () => {
   });
 
   it('should render EuiFieldNumber with correct props', () => {
-    const fieldNumber = wrapper.find('EuiFieldNumber');
+    const fieldNumber = wrapper.find(EuiCompressedFieldNumber);
     expect(fieldNumber.prop('value')).toEqual(12);
     expect(fieldNumber.prop('append')).toEqual(<EuiFormLabel>px</EuiFormLabel>);
     expect(fieldNumber.prop('fullWidth')).toEqual(true);
   });
 
   it('should call setSelectedLayerConfig with updated config when OnChangeLabelSize is called', () => {
-    const fieldNumber = wrapper.find('EuiFieldNumber');
+    const fieldNumber = wrapper.find(EuiCompressedFieldNumber);
     fieldNumber.simulate('change', { target: { value: 20 } });
     expect(setSelectedLayerConfigMock).toHaveBeenCalledWith({
       ...mockLayerConfig,
@@ -206,7 +214,7 @@ describe('LabelConfig', () => {
   });
 
   it('should render EuiSelect with correct props for label border width', () => {
-    const select = wrapper.find('EuiSelect').at(1);
+    const select = wrapper.find(EuiCompressedSelect).at(1);
     expect(select.prop('options')).toEqual([
       { value: DOCUMENTS_NONE_LABEL_BORDER_WIDTH, text: 'None' },
       { value: DOCUMENTS_SMALL_LABEL_BORDER_WIDTH, text: 'Small' },
@@ -218,7 +226,7 @@ describe('LabelConfig', () => {
   });
 
   it('should call setSelectedLayerConfig with updated config when onChangeLabelBorderWidth is called', () => {
-    const select = wrapper.find('EuiSelect').at(1);
+    const select = wrapper.find(EuiCompressedSelect).at(1);
     select.simulate('change', { target: { value: 3 } });
     expect(setSelectedLayerConfigMock).toHaveBeenCalledWith({
       ...mockLayerConfig,

--- a/public/components/layer_config/documents_config/style/label_config.tsx
+++ b/public/components/layer_config/documents_config/style/label_config.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useMemo, ChangeEventHandler, ChangeEvent } from 'react';
 import {
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiFlexItem,
   EuiCheckbox,
@@ -170,17 +170,17 @@ export const LabelConfig = ({
 
   return (
     <>
-      <EuiFormRow>
+      <EuiCompressedFormRow>
         <EuiCheckbox
           id="show-label"
           label="Add label"
           checked={label?.enabled ?? false}
           onChange={onChangeShowLabel}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       {label?.enabled && (
         <>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label={i18n.translate('maps.documents.labelText', {
               defaultMessage: 'Label text',
             })}
@@ -225,8 +225,8 @@ export const LabelConfig = ({
                 )}
               </EuiFlexItem>
             </EuiFlexGroup>
-          </EuiFormRow>
-          <EuiFormRow
+          </EuiCompressedFormRow>
+          <EuiCompressedFormRow
             label={i18n.translate('maps.documents.labelSize', {
               defaultMessage: 'Label size',
             })}
@@ -246,7 +246,7 @@ export const LabelConfig = ({
               min={DOCUMENTS_MIN_LABEL_SIZE}
               max={DOCUMENTS_MAX_LABEL_SIZE}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <ColorPicker
             originColor={label?.color ?? DOCUMENTS_DEFAULT_LABEL_COLOR}
             label={i18n.translate('maps.documents.labelColor', {
@@ -263,7 +263,7 @@ export const LabelConfig = ({
             setIsUpdateDisabled={setIsUpdateDisabled}
             onColorChange={onChangeLabelBorderColor}
           />
-          <EuiFormRow
+          <EuiCompressedFormRow
             label={i18n.translate('maps.documents.labelBorderWidth', {
               defaultMessage: 'Label border width',
             })}
@@ -274,7 +274,7 @@ export const LabelConfig = ({
               onChange={onChangeLabelBorderWidth}
               fullWidth={true}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
     </>

--- a/public/components/layer_config/documents_config/style/label_config.tsx
+++ b/public/components/layer_config/documents_config/style/label_config.tsx
@@ -9,7 +9,7 @@ import {
   EuiCompressedFieldText,
   EuiFlexItem,
   EuiCheckbox,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiFlexGroup,
   EuiCompressedFieldNumber,
   EuiFormLabel,
@@ -191,7 +191,7 @@ export const LabelConfig = ({
           >
             <EuiFlexGroup responsive={false} alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
-                <EuiSelect
+                <EuiCompressedSelect
                   options={labelTextTypeOptions}
                   value={label?.textType ?? DOCUMENTS_DEFAULT_LABEL_TEXT_TYPE}
                   onChange={onChangeLabelTextType}
@@ -268,7 +268,7 @@ export const LabelConfig = ({
               defaultMessage: 'Label border width',
             })}
           >
-            <EuiSelect
+            <EuiCompressedSelect
               options={labelBorderWidthOptions}
               value={label?.borderWidth ?? DOCUMENTS_NONE_LABEL_BORDER_WIDTH}
               onChange={onChangeLabelBorderWidth}

--- a/public/components/layer_config/documents_config/style/label_config.tsx
+++ b/public/components/layer_config/documents_config/style/label_config.tsx
@@ -6,12 +6,12 @@
 import React, { useEffect, useMemo, ChangeEventHandler, ChangeEvent } from 'react';
 import {
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexItem,
   EuiCheckbox,
   EuiSelect,
   EuiFlexGroup,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFormLabel,
   EuiComboBox,
 } from '@elastic/eui';
@@ -199,7 +199,7 @@ export const LabelConfig = ({
               </EuiFlexItem>
               <EuiFlexItem className={'documentsLabel__text'}>
                 {label?.textType === DOCUMENTS_LABEL_TEXT_TYPE.FIXED && (
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     placeholder={i18n.translate('maps.documents.labelTextPlaceholder', {
                       defaultMessage: 'Enter label text',
                     })}
@@ -235,7 +235,7 @@ export const LabelConfig = ({
               defaultMessage: `Must be between ${DOCUMENTS_MIN_LABEL_SIZE} and ${DOCUMENTS_MAX_LABEL_SIZE}`,
             })}
           >
-            <EuiFieldNumber
+            <EuiCompressedFieldNumber
               placeholder={i18n.translate('maps.documents.labelSizePlaceholder', {
                 defaultMessage: 'Select size',
               })}

--- a/public/components/layer_config/documents_config/style/label_config.tsx
+++ b/public/components/layer_config/documents_config/style/label_config.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexGroup,
   EuiCompressedFieldNumber,
   EuiFormLabel,
-  EuiComboBox,
+  EuiCompressedComboBox,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { EuiComboBoxOptionOption } from '@opensearch-project/oui/src/eui_components/combo_box/types';
@@ -209,7 +209,7 @@ export const LabelConfig = ({
                   />
                 )}
                 {(!label?.textType || label?.textType === DOCUMENTS_LABEL_TEXT_TYPE.BY_FIELD) && (
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     options={getFieldsOptions(indexPattern)}
                     selectedOptions={formatFieldStringToComboBox(label?.textByField)}
                     singleSelection={{ asPlainText: true }}

--- a/public/components/layer_config/documents_config/style/label_config.tsx
+++ b/public/components/layer_config/documents_config/style/label_config.tsx
@@ -8,7 +8,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiFlexItem,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiCompressedSelect,
   EuiFlexGroup,
   EuiCompressedFieldNumber,
@@ -171,7 +171,7 @@ export const LabelConfig = ({
   return (
     <>
       <EuiCompressedFormRow>
-        <EuiCheckbox
+        <EuiCompressedCheckbox
           id="show-label"
           label="Add label"
           checked={label?.enabled ?? false}

--- a/public/components/layer_config/layer_basic_settings.test.tsx
+++ b/public/components/layer_config/layer_basic_settings.test.tsx
@@ -8,7 +8,13 @@ import { LayerBasicSettings } from './layer_basic_settings';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import { DASHBOARDS_MAPS_LAYER_TYPE, MAX_LAYER_NAME_LIMIT } from '../../../common';
 import { shallow } from 'enzyme';
-import { EuiDualRange, EuiFieldText, EuiFormRow, EuiRange, EuiTextArea } from '@elastic/eui';
+import {
+  EuiCompressedDualRange,
+  EuiCompressedFieldText,
+  EuiCompressedFormRow,
+  EuiRange,
+  EuiCompressedTextArea
+} from '@elastic/eui';
 
 describe('LayerBasicSettings', () => {
   let wrapper: any;
@@ -34,15 +40,15 @@ describe('LayerBasicSettings', () => {
   });
 
   it('should render with correct props', () => {
-    expect(wrapper.find(EuiFieldText).prop('value')).toBe(mockLayerConfig.name);
-    expect(wrapper.find(EuiTextArea).prop('value')).toBe(mockLayerConfig.description);
-    expect(wrapper.find(EuiDualRange).prop('value')).toEqual(mockLayerConfig.zoomRange);
+    expect(wrapper.find(EuiCompressedFieldText).prop('value')).toBe(mockLayerConfig.name);
+    expect(wrapper.find(EuiCompressedTextArea).prop('value')).toBe(mockLayerConfig.description);
+    expect(wrapper.find(EuiCompressedDualRange).prop('value')).toEqual(mockLayerConfig.zoomRange);
     expect(wrapper.find(EuiRange).prop('value')).toEqual(mockLayerConfig.opacity);
   });
 
   it('should call setSelectedLayerConfig with updated zoom range on zoom level change', () => {
     const newZoomRange = [2, 15];
-    wrapper.find(EuiDualRange).simulate('change', newZoomRange);
+    wrapper.find(EuiCompressedDualRange).simulate('change', newZoomRange);
 
     expect(mockProps.setSelectedLayerConfig).toHaveBeenCalledWith({
       ...mockLayerConfig,
@@ -62,7 +68,7 @@ describe('LayerBasicSettings', () => {
 
   it('should call setSelectedLayerConfig with updated name on name change', () => {
     const newName = 'Updated Test Layer';
-    wrapper.find(EuiFieldText).simulate('change', { target: { value: newName } });
+    wrapper.find(EuiCompressedFieldText).simulate('change', { target: { value: newName } });
 
     expect(mockProps.setSelectedLayerConfig).toHaveBeenCalledWith({
       ...mockLayerConfig,
@@ -72,7 +78,7 @@ describe('LayerBasicSettings', () => {
 
   it('should call setSelectedLayerConfig with updated description on description change', () => {
     const newDescription = 'Updated description';
-    wrapper.find(EuiTextArea).simulate('change', { target: { value: newDescription } });
+    wrapper.find(EuiCompressedTextArea).simulate('change', { target: { value: newDescription } });
 
     expect(mockProps.setSelectedLayerConfig).toHaveBeenCalledWith({
       ...mockLayerConfig,
@@ -83,20 +89,20 @@ describe('LayerBasicSettings', () => {
   it('should display an error for an empty name', () => {
     mockProps.isLayerExists.mockReturnValue(false); // Ensure this returns false for this test
     const emptyName = '';
-    wrapper.find(EuiFieldText).simulate('change', { target: { value: emptyName } });
+    wrapper.find(EuiCompressedFieldText).simulate('change', { target: { value: emptyName } });
 
     wrapper.update();
 
-    expect(wrapper.find(EuiFormRow).first().prop('error')).toContain('Name cannot be empty');
+    expect(wrapper.find(EuiCompressedFormRow).first().prop('error')).toContain('Name cannot be empty');
   });
 
   it('should display an error for a name exceeding the maximum length', () => {
     const longName = 'a'.repeat(MAX_LAYER_NAME_LIMIT + 1); // Create a name longer than MAX_LAYER_NAME_LIMIT
-    wrapper.find(EuiFieldText).simulate('change', { target: { value: longName } });
+    wrapper.find(EuiCompressedFieldText).simulate('change', { target: { value: longName } });
 
     wrapper.update();
 
-    expect(wrapper.find(EuiFormRow).first().prop('error')).toContain(
+    expect(wrapper.find(EuiCompressedFormRow).first().prop('error')).toContain(
       `Name should be less than ${MAX_LAYER_NAME_LIMIT} characters`
     );
   });
@@ -104,10 +110,10 @@ describe('LayerBasicSettings', () => {
   it('should display an error for a name that already exists', () => {
     mockProps.isLayerExists.mockReturnValue(true); // Simulate that the name already exists
     const existingName = 'Existing Layer Name';
-    wrapper.find(EuiFieldText).simulate('change', { target: { value: existingName } });
+    wrapper.find(EuiCompressedFieldText).simulate('change', { target: { value: existingName } });
 
     wrapper.update();
 
-    expect(wrapper.find(EuiFormRow).first().prop('error')).toContain('Name already exists');
+    expect(wrapper.find(EuiCompressedFormRow).first().prop('error')).toContain('Name already exists');
   });
 });

--- a/public/components/layer_config/layer_basic_settings.tsx
+++ b/public/components/layer_config/layer_basic_settings.tsx
@@ -8,7 +8,7 @@ import {
   EuiDualRange,
   EuiFieldText,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiTitle,
   EuiSpacer,
   EuiRange,
@@ -106,7 +106,7 @@ export const LayerBasicSettings = ({
       </EuiTitle>
       <EuiSpacer size="m" />
       <EuiForm>
-        <EuiFormRow label="Name" error={errors} isInvalid={invalid} fullWidth={true}>
+        <EuiCompressedFormRow label="Name" error={errors} isInvalid={invalid} fullWidth={true}>
           <EuiFieldText
             name="layerName"
             value={selectedLayerConfig.name}
@@ -114,18 +114,18 @@ export const LayerBasicSettings = ({
             isInvalid={invalid}
             fullWidth={true}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
-        <EuiFormRow label="Description" fullWidth={true}>
+        <EuiCompressedFormRow label="Description" fullWidth={true}>
           <EuiTextArea
             placeholder="Enter description"
             value={selectedLayerConfig.description}
             onChange={onDescriptionChange}
             fullWidth={true}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
-        <EuiFormRow label="Zoom levels" fullWidth={true}>
+        <EuiCompressedFormRow label="Zoom levels" fullWidth={true}>
           <EuiDualRange
             min={MAP_DEFAULT_MIN_ZOOM}
             max={MAP_DEFAULT_MAX_ZOOM}
@@ -137,8 +137,8 @@ export const LayerBasicSettings = ({
             aria-label="DualRange with inputs for zoom level"
             fullWidth={true}
           />
-        </EuiFormRow>
-        <EuiFormRow label="Opacity" fullWidth={true}>
+        </EuiCompressedFormRow>
+        <EuiCompressedFormRow label="Opacity" fullWidth={true}>
           <EuiRange
             min={MAP_LAYER_DEFAULT_MIN_OPACITY}
             max={MAP_LAYER_DEFAULT_MAX_OPACITY}
@@ -150,7 +150,7 @@ export const LayerBasicSettings = ({
             append={<EuiFormLabel>%</EuiFormLabel>}
             fullWidth={true}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiForm>
     </EuiPanel>
   );

--- a/public/components/layer_config/layer_basic_settings.tsx
+++ b/public/components/layer_config/layer_basic_settings.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   EuiDualRange,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
   EuiTitle,
@@ -107,7 +107,7 @@ export const LayerBasicSettings = ({
       <EuiSpacer size="m" />
       <EuiForm>
         <EuiCompressedFormRow label="Name" error={errors} isInvalid={invalid} fullWidth={true}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             name="layerName"
             value={selectedLayerConfig.name}
             onChange={onNameChange}

--- a/public/components/layer_config/layer_basic_settings.tsx
+++ b/public/components/layer_config/layer_basic_settings.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import {
-  EuiDualRange,
+  EuiCompressedDualRange,
   EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
@@ -126,7 +126,7 @@ export const LayerBasicSettings = ({
         </EuiCompressedFormRow>
 
         <EuiCompressedFormRow label="Zoom levels" fullWidth={true}>
-          <EuiDualRange
+          <EuiCompressedDualRange
             min={MAP_DEFAULT_MIN_ZOOM}
             max={MAP_DEFAULT_MAX_ZOOM}
             value={zoomLevel}

--- a/public/components/layer_config/layer_basic_settings.tsx
+++ b/public/components/layer_config/layer_basic_settings.tsx
@@ -14,7 +14,7 @@ import {
   EuiRange,
   EuiPanel,
   EuiFormLabel,
-  EuiTextArea,
+  EuiCompressedTextArea,
 } from '@elastic/eui';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import {
@@ -117,7 +117,7 @@ export const LayerBasicSettings = ({
         </EuiCompressedFormRow>
 
         <EuiCompressedFormRow label="Description" fullWidth={true}>
-          <EuiTextArea
+          <EuiCompressedTextArea
             placeholder="Enter description"
             value={selectedLayerConfig.description}
             onChange={onDescriptionChange}

--- a/public/components/layer_config/layer_config_panel.tsx
+++ b/public/components/layer_config/layer_config_panel.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { cloneDeep, isEqual } from 'lodash';
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
@@ -161,7 +161,7 @@ export const LayerConfigPanel = ({
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               disabled={isUpdateDisabled}
               iconType="play"
               onClick={onUpdate}
@@ -169,7 +169,7 @@ export const LayerConfigPanel = ({
               data-test-subj="updateButton"
             >
               Update
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutFooter>
@@ -183,9 +183,9 @@ export const LayerConfigPanel = ({
           </EuiModalBody>
           <EuiModalFooter>
             <EuiButtonEmpty onClick={closeModal}>Cancel</EuiButtonEmpty>
-            <EuiButton onClick={discardChanges} fill>
+            <EuiSmallButton onClick={discardChanges} fill>
               Discard
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       )}

--- a/public/components/layer_config/layer_config_panel.tsx
+++ b/public/components/layer_config/layer_config_panel.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiFlexItem,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiModal,
   EuiModalBody,
@@ -156,9 +156,9 @@ export const LayerConfigPanel = ({
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty iconType="cross" onClick={onClose} flush="left">
+            <EuiSmallButtonEmpty iconType="cross" onClick={onClose} flush="left">
               Discard
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton
@@ -182,7 +182,7 @@ export const LayerConfigPanel = ({
             <p>Do you want to discard the changes?</p>
           </EuiModalBody>
           <EuiModalFooter>
-            <EuiButtonEmpty onClick={closeModal}>Cancel</EuiButtonEmpty>
+            <EuiSmallButtonEmpty onClick={closeModal}>Cancel</EuiSmallButtonEmpty>
             <EuiSmallButton onClick={discardChanges} fill>
               Discard
             </EuiSmallButton>

--- a/public/components/maps_list/maps_list.tsx
+++ b/public/components/maps_list/maps_list.tsx
@@ -11,7 +11,7 @@ import {
   EuiPageBody,
   EuiPageContentBody,
   EuiLink,
-  EuiButton,
+  EuiSmallButton,
   EuiPageHeader,
 } from '@elastic/eui';
 import {
@@ -110,9 +110,9 @@ export const MapsList = () => {
       pageTitle="Create your first map"
       description="There is no map to display, let's create your first map."
       rightSideItems={[
-        <EuiButton fill onClick={navigateToCreateMapPage}>
+        <EuiSmallButton fill onClick={navigateToCreateMapPage}>
           Create map
-        </EuiButton>,
+        </EuiSmallButton>,
       ]}
     />
   );

--- a/public/components/show_error_modal.tsx
+++ b/public/components/show_error_modal.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState } from 'react';
 import {
+  EuiSmallButton,
   EuiButton,
   EuiModal,
   EuiModalBody,
@@ -42,7 +43,7 @@ const ShowErrorModal = (props: ShowErrorModalProps) => {
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButton
+          <EuiSmallButton
             id="closeModal"
             aria-label="closeModal"
             data-testid="closeModal"
@@ -50,7 +51,7 @@ const ShowErrorModal = (props: ShowErrorModalProps) => {
             fill
           >
             Close
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     );

--- a/public/components/toolbar/spatial_filter/filter_input_panel.tsx
+++ b/public/components/toolbar/spatial_filter/filter_input_panel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiButton, EuiFieldText, EuiForm, EuiFormRow, EuiPanel, EuiSelect } from '@elastic/eui';
+import { EuiButton, EuiCompressedFieldText, EuiForm, EuiFormRow, EuiPanel, EuiSelect } from '@elastic/eui';
 import { FILTER_DRAW_MODE } from '../../../../common';
 
 const getSpatialRelationshipItems = (
@@ -56,7 +56,7 @@ export const FilterInputPanel = ({
     <EuiPanel className={'spatialFilterGroup__popoverPanel'}>
       <EuiForm>
         <EuiFormRow label="Filter label" display="rowCompressed">
-          <EuiFieldText
+          <EuiCompressedFieldText
             name="filterLabel"
             value={filterLabel}
             onChange={(event) => {

--- a/public/components/toolbar/spatial_filter/filter_input_panel.tsx
+++ b/public/components/toolbar/spatial_filter/filter_input_panel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiButton, EuiCompressedFieldText, EuiForm, EuiFormRow, EuiPanel, EuiSelect } from '@elastic/eui';
+import { EuiButton, EuiFieldText, EuiForm, EuiFormRow, EuiPanel, EuiSelect } from '@elastic/eui';
 import { FILTER_DRAW_MODE } from '../../../../common';
 
 const getSpatialRelationshipItems = (
@@ -56,7 +56,7 @@ export const FilterInputPanel = ({
     <EuiPanel className={'spatialFilterGroup__popoverPanel'}>
       <EuiForm>
         <EuiFormRow label="Filter label" display="rowCompressed">
-          <EuiCompressedFieldText
+          <EuiFieldText
             name="filterLabel"
             value={filterLabel}
             onChange={(event) => {

--- a/public/components/tooltip/tooltipHeaderContent.tsx
+++ b/public/components/tooltip/tooltipHeaderContent.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiTextColor } from '@elastic/eui';
+import { EuiSmallButtonIcon, EuiFlexGroup, EuiFlexItem, EuiTextColor } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import React from 'react';
 
@@ -25,7 +25,7 @@ const TooltipHeaderContent = (props: Props) => {
       </EuiFlexItem>
       {props.showCloseButton && (
         <EuiFlexItem key="closeButton" grow={false}>
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             onClick={() => {
               return props.onClose();
             }}

--- a/public/components/tooltip/tooltipTable.tsx
+++ b/public/components/tooltip/tooltipTable.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBasicTable,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -170,7 +170,7 @@ const TooltipTable = ({
       <EuiFlexGroup justifyContent="spaceAround" alignItems="center" gutterSize="none">
         {showLayerSelection && options?.length > 1 && (
           <EuiFlexItem>
-            <EuiComboBox<number>
+            <EuiCompressedComboBox<number>
               placeholder="Select a layer"
               selectedOptions={selectedLayers}
               singleSelection={{ asPlainText: true }}

--- a/public/components/vector_upload_options.tsx
+++ b/public/components/vector_upload_options.tsx
@@ -8,7 +8,7 @@ import React, { useState } from 'react';
 import path from 'path';
 import {
   EuiSmallButton,
-  EuiFilePicker,
+  EuiCompressedFilePicker,
   EuiFlexItem,
   EuiFlexGroup,
   EuiText,
@@ -324,7 +324,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
         <EuiSpacer size="m" aria-label="medium-spacer" />
 
         <EuiCompressedFormRow aria-label="form-row-for-file-picker">
-          <EuiFilePicker
+          <EuiCompressedFilePicker
             id="filePicker"
             data-testid="filePicker"
             data-test-subj="filePicker"

--- a/public/components/vector_upload_options.tsx
+++ b/public/components/vector_upload_options.tsx
@@ -14,7 +14,7 @@ import {
   EuiText,
   EuiSpacer,
   EuiCard,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiTextColor,
   EuiCompressedFormRow,
   EuiCodeBlock,
@@ -356,7 +356,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
         </EuiText>
         <EuiSpacer size="m" aria-label="medium-spacer" />
 
-        <EuiFieldText
+        <EuiCompressedFieldText
           data-testid="customIndex"
           data-test-subj="customIndex"
           tabIndex="0"

--- a/public/components/vector_upload_options.tsx
+++ b/public/components/vector_upload_options.tsx
@@ -7,7 +7,7 @@ import './vector_upload_options.scss';
 import React, { useState } from 'react';
 import path from 'path';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFilePicker,
   EuiFlexItem,
   EuiFlexGroup,
@@ -391,7 +391,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
         <EuiSpacer size="m" aria-label="medium-spacer" />
 
         <div className="importFileButton">
-          <EuiButton
+          <EuiSmallButton
             id="submitButton"
             type="button"
             fill
@@ -400,7 +400,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
             aria-label="import-file-button"
           >
             Import file
-          </EuiButton>
+          </EuiSmallButton>
         </div>
       </EuiCard>
     </div>

--- a/public/components/vector_upload_options.tsx
+++ b/public/components/vector_upload_options.tsx
@@ -16,7 +16,7 @@ import {
   EuiCard,
   EuiFieldText,
   EuiTextColor,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiCodeBlock,
 } from '@elastic/eui';
 import { getIndex, postGeojson } from '../services';
@@ -323,7 +323,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
         </EuiText>
         <EuiSpacer size="m" aria-label="medium-spacer" />
 
-        <EuiFormRow aria-label="form-row-for-file-picker">
+        <EuiCompressedFormRow aria-label="form-row-for-file-picker">
           <EuiFilePicker
             id="filePicker"
             data-testid="filePicker"
@@ -337,7 +337,7 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
             required={true}
             aria-label="geojson-file-picker"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer size="m" aria-label="medium-spacer" />
 
         <EuiText size="xs" color="subdued" aria-label="geojson-file-format-text">

--- a/public/components/vector_upload_options.tsx
+++ b/public/components/vector_upload_options.tsx
@@ -7,6 +7,7 @@ import './vector_upload_options.scss';
 import React, { useState } from 'react';
 import path from 'path';
 import {
+  EuiButton,
   EuiSmallButton,
   EuiCompressedFilePicker,
   EuiFlexItem,


### PR DESCRIPTION
### Description
Replace instances of `EuiButton` that don't have an explicit sizing attribute to `EuiSmallButton*`.
Replace instances of `Eui<form elements>` that don't have density attributes to `EuiCompressed<form elements>`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
