### PR TITLE
Deprecate maps multi data source display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 ### Documentation
 ### Maintenance
+* Deprecated maps multi data source display [#651](https://github.com/opensearch-project/dashboards-maps/pull/651)
 ### Refactoring

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -5,5 +5,5 @@
     "server": true,
     "ui": true,
     "requiredPlugins": ["regionMap", "opensearchDashboardsReact", "opensearchDashboardsUtils", "navigation", "savedObjects", "data", "embeddable", "visualizations"],
-    "optionalPlugins": ["home", "dataSource", "dataSourceManagement"]
+    "optionalPlugins": ["home"]
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/react-test-renderer": "^18.0.7",
-    "cypress": "^13.6.3",
+    "cypress": "^13.6.2",
     "cypress-multi-reporters": "^1.5.0",
     "prettier": "^2.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/react-test-renderer": "^18.0.7",
-    "cypress": "^13.6.2",
+    "cypress": "^13.6.3",
     "cypress-multi-reporters": "^1.5.0",
     "prettier": "^2.1.1"
   }

--- a/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/public/components/layer_control_panel/layer_control_panel.tsx
@@ -29,7 +29,7 @@ import { IndexPattern } from '../../../../../src/plugins/data/public';
 import { AddLayerPanel } from '../add_layer_panel';
 import { LayerConfigPanel } from '../layer_config';
 import { MapLayerSpecification } from '../../model/mapLayerType';
-import { DASHBOARDS_MAPS_LAYER_TYPE, LAYER_ICON_TYPE_MAP } from '../../../common';
+import { LAYER_ICON_TYPE_MAP } from '../../../common';
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { MapServices } from '../../types';
 import { MapState } from '../../model/mapState';
@@ -49,7 +49,6 @@ interface Props {
   selectedLayerConfig: MapLayerSpecification | undefined;
   setSelectedLayerConfig: (layerConfig: MapLayerSpecification | undefined) => void;
   setIsUpdatingLayerRender: (isUpdatingLayerRender: boolean) => void;
-  setDataSourceRefIds: (dataSourceRefIds: string[]) => void;
 }
 
 export const LayerControlPanel = memo(
@@ -57,14 +56,11 @@ export const LayerControlPanel = memo(
     maplibreRef,
     setLayers,
     layers,
-    layersIndexPatterns,
-    setLayersIndexPatterns,
     zoom,
     isReadOnlyMode,
     selectedLayerConfig,
     setSelectedLayerConfig,
     setIsUpdatingLayerRender,
-    setDataSourceRefIds,
   }: Props) => {
     const { services } = useOpenSearchDashboards<MapServices>();
 
@@ -209,39 +205,12 @@ export const LayerControlPanel = memo(
       setIsDeleteLayerModalVisible(true);
     };
 
-    const removeDataLayerDataSource = (layer: MapLayerSpecification) => {
-      if (layer.type === DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS) {
-        const indexPatternId = layer.source.indexPatternId;
-        const indexPattern = layersIndexPatterns.find((idp) => idp.id === indexPatternId);
-        if (indexPattern) {
-          const indexPatternClone = [...layersIndexPatterns];
-          const index = indexPatternClone.findIndex((idp) => idp.id === indexPatternId);
-          if (index > -1) {
-            indexPatternClone.splice(index, 1);
-            setLayersIndexPatterns(indexPatternClone);
-          }
-          // remove duplicate dataSourceRefIds
-          const updatedDataSourceRefIds : string[] = [];
-          indexPatternClone.forEach((ip) => {
-            if (ip.dataSourceRef && !updatedDataSourceRefIds.includes(ip.dataSourceRef.id)) {
-              updatedDataSourceRefIds.push(ip.dataSourceRef.id);
-            } else if (!ip.dataSourceRef && !updatedDataSourceRefIds.includes('')) {
-              updatedDataSourceRefIds.push('');
-            }
-          });
-
-          setDataSourceRefIds(updatedDataSourceRefIds);
-        }
-      }
-    };
-
     const onDeleteLayerConfirm = () => {
       if (selectedDeleteLayer) {
         removeLayers(maplibreRef.current!, selectedDeleteLayer.id, true);
         removeLayer(selectedDeleteLayer.id);
         setIsDeleteLayerModalVisible(false);
         setSelectedDeleteLayer(undefined);
-        removeDataLayerDataSource(selectedDeleteLayer);
       }
     };
 

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -46,8 +46,6 @@ interface MapContainerProps {
   isUpdatingLayerRender: boolean;
   setIsUpdatingLayerRender: (isUpdatingLayerRender: boolean) => void;
   addSpatialFilter: (shape: ShapeFilter, label: string | null, relation: GeoShapeRelation) => void;
-  dataSourceRefIds: string[];
-  setDataSourceRefIds: (refIds: string[]) => void;
 }
 
 export class MapsServiceError extends Error {
@@ -69,7 +67,6 @@ export const MapContainer = ({
   isUpdatingLayerRender,
   setIsUpdatingLayerRender,
   addSpatialFilter,
-  setDataSourceRefIds,
 }: MapContainerProps) => {
   const { services } = useOpenSearchDashboards<MapServices>();
 
@@ -248,16 +245,6 @@ export const MapContainer = ({
       );
       const cloneLayersIndexPatterns = [...layersIndexPatterns, newIndexPattern];
       setLayersIndexPatterns(cloneLayersIndexPatterns);
-      const updatedDataSourceRefIds: string[] = [];
-      cloneLayersIndexPatterns.forEach((ip) => {
-        if (ip.dataSourceRef && !updatedDataSourceRefIds.includes(ip.dataSourceRef.id)) {
-          updatedDataSourceRefIds.push(ip.dataSourceRef.id);
-        } else if (!ip.dataSourceRef && !updatedDataSourceRefIds.includes('')) {
-          // If index pattern of the layer doesn't have reference to a data source, it is using local cluster
-          updatedDataSourceRefIds.push('');
-        }
-      });
-      setDataSourceRefIds(updatedDataSourceRefIds);
     }
   };
 
@@ -284,7 +271,6 @@ export const MapContainer = ({
           selectedLayerConfig={selectedLayerConfig}
           setSelectedLayerConfig={setSelectedLayerConfig}
           setIsUpdatingLayerRender={setIsUpdatingLayerRender}
-          setDataSourceRefIds={setDataSourceRefIds}
         />
       )}
       {mounted && tooltipState === TOOLTIP_STATE.DISPLAY_FEATURES && maplibreRef.current && (

--- a/public/components/map_top_nav/top_nav_menu.tsx
+++ b/public/components/map_top_nav/top_nav_menu.tsx
@@ -26,7 +26,6 @@ interface MapTopNavMenuProps {
   setMapState: (mapState: MapState) => void;
   originatingApp?: string;
   setIsUpdatingLayerRender: (isUpdatingLayerRender: boolean) => void;
-  dataSourceRefIds: string[];
 }
 
 export const MapTopNavMenu = ({
@@ -38,7 +37,6 @@ export const MapTopNavMenu = ({
   mapState,
   setMapState,
   setIsUpdatingLayerRender,
-  dataSourceRefIds,
 }: MapTopNavMenuProps) => {
   const { services } = useOpenSearchDashboards<MapServices>();
   const {
@@ -50,9 +48,6 @@ export const MapTopNavMenu = ({
     application: { navigateToApp },
     embeddable,
     scopedHistory,
-    dataSourceManagement,
-    savedObjects: { client: savedObjectsClient },
-    notifications,
   } = services;
 
   const [title, setTitle] = useState<string>('');
@@ -137,42 +132,27 @@ export const MapTopNavMenu = ({
     });
   }, [services, mapIdFromUrl, layers, title, description, mapState, originatingApp]);
 
-  const dataSourceManagementEnabled: boolean = !!dataSourceManagement;
-
   return (
     // @ts-ignore
-    <>
-      <TopNavMenu
-        appName={MAPS_APP_ID}
-        config={config}
-        setMenuMountPoint={setHeaderActionMenu}
-        indexPatterns={layersIndexPatterns || []}
-        showSearchBar={true}
-        showFilterBar={false}
-        showDatePicker={true}
-        showQueryBar={true}
-        showSaveQuery={true}
-        showQueryInput={true}
-        onQuerySubmit={handleQuerySubmit}
-        dateRangeFrom={dateFrom}
-        dateRangeTo={dateTo}
-        query={queryConfig}
-        isRefreshPaused={isRefreshPaused}
-        refreshInterval={refreshIntervalValue}
-        onRefresh={refreshDataLayerRender}
-        onRefreshChange={onRefreshChange}
-        showDataSourceMenu={dataSourceManagementEnabled}
-        dataSourceMenuConfig={{
-          componentType: 'DataSourceAggregatedView',
-          componentConfig: {
-            activeDataSourceIds: dataSourceRefIds,
-            savedObjects: savedObjectsClient,
-            notifications,
-            fullWidth: true,
-            displayAllCompatibleDataSources: false,
-          },
-        }}
-      />
-    </>
+    <TopNavMenu
+      appName={MAPS_APP_ID}
+      config={config}
+      setMenuMountPoint={setHeaderActionMenu}
+      indexPatterns={layersIndexPatterns || []}
+      showSearchBar={true}
+      showFilterBar={false}
+      showDatePicker={true}
+      showQueryBar={true}
+      showSaveQuery={true}
+      showQueryInput={true}
+      onQuerySubmit={handleQuerySubmit}
+      dateRangeFrom={dateFrom}
+      dateRangeTo={dateTo}
+      query={queryConfig}
+      isRefreshPaused={isRefreshPaused}
+      refreshInterval={refreshIntervalValue}
+      onRefresh={refreshDataLayerRender}
+      onRefreshChange={onRefreshChange}
+    />
   );
 };

--- a/public/components/maps_list/maps_list.tsx
+++ b/public/components/maps_list/maps_list.tsx
@@ -22,7 +22,6 @@ import { MapSavedObjectAttributes } from '../../../common/map_saved_object_attri
 import { MapServices } from '../../types';
 import { getMapsLandingBreadcrumbs } from '../../utils/breadcrumbs';
 import { APP_PATH, MAPS_APP_ID } from '../../../common';
-import { DataSourceAggregatedViewConfig } from '../../../../../src/plugins/data_source_management/public';
 
 export const MapsList = () => {
   const {
@@ -31,8 +30,6 @@ export const MapsList = () => {
       savedObjects: { client: savedObjectsClient },
       application: { navigateToApp },
       chrome: { docTitle, setBreadcrumbs },
-      dataSourceManagement,
-      setActionMenu,
     },
   } = useOpenSearchDashboards<MapServices>();
 
@@ -116,7 +113,6 @@ export const MapsList = () => {
       ]}
     />
   );
-  const dataSourceManagementEnabled: boolean = !!dataSourceManagement;
 
   return (
     <I18nProvider>
@@ -124,21 +120,6 @@ export const MapsList = () => {
         <EuiPage restrictWidth="1000px">
           <EuiPageBody component="main" data-test-subj="mapListingPage">
             <EuiPageContentBody>
-              {dataSourceManagementEnabled && (() => {
-                const DataSourcesMenu = dataSourceManagement.ui.getDataSourceMenu<DataSourceAggregatedViewConfig>();
-                return (
-                  <DataSourcesMenu
-                    setMenuMountPoint={setActionMenu}
-                    componentType={'DataSourceAggregatedView'}
-                    componentConfig={{
-                      savedObjects: savedObjectsClient,
-                      notifications,
-                      fullWidth: true,
-                      displayAllCompatibleDataSources: true,
-                    }}
-                  />
-                );
-              })()}
               <TableListView
                 headingId="mapsListingHeading"
                 createItem={navigateToCreateMapPage}

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -47,12 +47,11 @@ export class CustomImportMapPlugin
   }
   public setup(
     core: CoreSetup,
-    { regionMap, embeddable, visualizations, dataSourceManagement }: AppPluginSetupDependencies
+    { regionMap, embeddable, visualizations }: AppPluginSetupDependencies
   ): CustomImportMapPluginSetup {
     const mapConfig: ConfigSchema = {
       ...this._initializerContext.config.get<ConfigSchema>(),
     };
-    const dataSourceManagentEnabled: boolean = !!dataSourceManagement;
     // Register an application into the side navigation menu
     core.application.register({
       id: MAPS_APP_ID,
@@ -93,12 +92,10 @@ export class CustomImportMapPlugin
           scopedHistory: params.history,
           uiSettings: coreStart.uiSettings,
           mapConfig,
-          dataSourceManagement,
-          setActionMenu: params.setHeaderActionMenu,
         };
         params.element.classList.add('mapAppContainer');
         // Render the application
-        return renderApp(params, services, dataSourceManagentEnabled);
+        return renderApp(params, services);
       },
     });
 

--- a/public/types.ts
+++ b/public/types.ts
@@ -9,7 +9,6 @@ import {
   SavedObjectsClient,
   ToastsStart,
   ScopedHistory,
-  MountPoint,
 } from '../../../src/core/public';
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '../../../src/plugins/data/public';
@@ -17,7 +16,6 @@ import { RegionMapPluginSetup } from '../../../src/plugins/region_map/public';
 import { EmbeddableSetup, EmbeddableStart } from '../../../src/plugins/embeddable/public';
 import { VisualizationsSetup } from '../../../src/plugins/visualizations/public';
 import { ConfigSchema } from '../common/config';
-import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 
 export interface AppPluginStartDependencies {
   navigation: NavigationPublicPluginStart;
@@ -43,8 +41,6 @@ export interface MapServices extends CoreStart {
   chrome: CoreStart['chrome'];
   uiSettings: CoreStart['uiSettings'];
   mapConfig: ConfigSchema;
-  dataSourceManagement: DataSourceManagementPluginSetup;
-  setActionMenu: (menuMount: MountPoint | undefined) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -58,5 +54,4 @@ export interface AppPluginSetupDependencies {
   embeddable: EmbeddableSetup;
   visualizations: VisualizationsSetup;
   data: DataPublicPluginSetup;
-  dataSourceManagement: DataSourceManagementPluginSetup;
 }


### PR DESCRIPTION
### Description
Deprecate maps multi data source display when `data_source` is enabled based on Trineo Maps UX mock.

### Issues Resolved
Part of https://github.com/opensearch-project/dashboards-maps/issues/649

### UI Changes
#### Before
<img width="1255" alt="Screenshot 2024-08-05 at 2 26 24 PM" src="https://github.com/user-attachments/assets/8ee6a4d0-c4cc-4968-9b30-c90948b0bc48">

<img width="1254" alt="Screenshot 2024-08-05 at 2 26 39 PM" src="https://github.com/user-attachments/assets/980867dd-7a84-4b95-90a3-360e7505b62e">

#### After
<img width="1257" alt="Screenshot 2024-08-05 at 2 27 04 PM" src="https://github.com/user-attachments/assets/97ce8c11-9217-4ab4-9a38-a6f8f6bee997">

<img width="1263" alt="Screenshot 2024-08-05 at 2 27 11 PM" src="https://github.com/user-attachments/assets/c9c6c4dc-0d29-4f67-b3b1-8049a31bef98">

<img width="1259" alt="Screenshot 2024-08-05 at 2 41 15 PM" src="https://github.com/user-attachments/assets/0b3cdaca-7848-4c61-a803-9c9a03d83cbf">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
