### PR TITLE
Use new header to maps listing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/dashboards-maps/compare/2.16...2.x)
 ### Features
+* Use new header to maps listing page [#653](https://github.com/opensearch-project/dashboards-maps/pull/653)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/public/components/maps_list/maps_list.tsx
+++ b/public/components/maps_list/maps_list.tsx
@@ -30,10 +30,17 @@ export const MapsList = () => {
       savedObjects: { client: savedObjectsClient },
       application: { navigateToApp },
       chrome: { docTitle, setBreadcrumbs },
+      uiSettings,
+      navigation: {
+        ui: { HeaderControl },
+      },
+      application,
     },
   } = useOpenSearchDashboards<MapServices>();
 
-  useEffect(() => {
+  const showActionsInHeader = uiSettings.get('home:useNewHomePage');
+
+    useEffect(() => {
     setBreadcrumbs(getMapsLandingBreadcrumbs(navigateToApp));
     docTitle.change(i18n.translate('maps.listing.pageTitle', { defaultMessage: 'Maps' }));
   }, [docTitle, navigateToApp, setBreadcrumbs]);
@@ -106,11 +113,17 @@ export const MapsList = () => {
     <EuiPageHeader
       pageTitle="Create your first map"
       description="There is no map to display, let's create your first map."
-      rightSideItems={[
-        <EuiSmallButton fill onClick={navigateToCreateMapPage}>
-          Create map
-        </EuiSmallButton>,
-      ]}
+      rightSideItems={
+        showActionsInHeader ? [] : [
+          <EuiSmallButton
+            fill
+            onClick={navigateToCreateMapPage}
+            data-test-subj="createFirstMapButton"
+          >
+            Create map
+          </EuiSmallButton>
+        ]
+      }
     />
   );
 
@@ -120,9 +133,24 @@ export const MapsList = () => {
         <EuiPage restrictWidth="1000px">
           <EuiPageBody component="main" data-test-subj="mapListingPage">
             <EuiPageContentBody>
+              {showActionsInHeader &&
+                <HeaderControl
+                  setMountPoint={application.setAppRightControls}
+                  controls={[
+                    {
+                      id: 'Create map',
+                      label: 'Create map',
+                      iconType: 'plus',
+                      fill: true,
+                      href: `${MAPS_APP_ID}${APP_PATH.CREATE_MAP}`,
+                      testId: 'createButton',
+                      controlType: 'button',
+                    },
+                  ]}
+                />}
               <TableListView
                 headingId="mapsListingHeading"
-                createItem={navigateToCreateMapPage}
+                createItem= { showActionsInHeader ? undefined : navigateToCreateMapPage }
                 findItems={fetchMaps}
                 deleteItems={deleteMaps}
                 tableColumns={tableColumns}

--- a/public/components/maps_list/maps_list.tsx
+++ b/public/components/maps_list/maps_list.tsx
@@ -164,9 +164,8 @@ export const MapsList = () => {
                 entityNamePlural={i18n.translate('maps.listing.table.entityNamePlural', {
                   defaultMessage: 'maps',
                 })}
-                tableListTitle={i18n.translate('maps.listing.table.listTitle', {
-                  defaultMessage: 'Maps',
-                })}
+                tableListTitle={showActionsInHeader ? '' : i18n.translate('maps.listing.table.listTitle', {
+                  defaultMessage: 'Maps'})}
                 toastNotifications={notifications.toasts}
               />
             </EuiPageContentBody>


### PR DESCRIPTION
### Description

This PR adds the changes to apply new header to maps listing page when turn on `home:useNewHomePage
` in advanced setting.

The code change in maps-dashboards plugin mainly is moving `Create map` button from table to header by using `HeaderControl` provided from OSD [header collective](https://github.com/AMoo-Miki/OpenSearch-Dashboards/tree/header-collective) branch  navigation component.

This PR is target to `feature/new-header` branch, since above OSD code change isn't available in main branch yet. Will add integ test after this PR and OSD feature code is merged to main.

### Screenshot
#### When turn off `home:useNewHomePage`(by default)
<img width="1487" alt="Screenshot 2024-08-09 at 12 56 41 PM" src="https://github.com/user-attachments/assets/1284ce43-0215-41b8-8b80-f00293b54ef9">


#### When turn on `home:useNewHomePage`

<img width="1494" alt="Screenshot 2024-08-09 at 12 56 13 PM" src="https://github.com/user-attachments/assets/ecc50a6e-6235-4fbe-91c1-9726ee3e6b09">



### Issues Resolved
Part of https://github.com/opensearch-project/dashboards-maps/issues/649

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
