### PR TITLE
Conditionally use the new Application Header variant on the Maps visualization page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/dashboards-maps/compare/2.16...2.x)
 ### Features
-* Use new header to maps listing page [#653](https://github.com/opensearch-project/dashboards-maps/pull/653)
-* Use new header to maps visualization page [#654](https://github.com/opensearch-project/dashboards-maps/pull/654)
+* Conditionally use the new Page Header variant on the Maps listing page [#653](https://github.com/opensearch-project/dashboards-maps/pull/653)
+* Conditionally use the new Application Header variant on the Maps visualization page [#654](https://github.com/opensearch-project/dashboards-maps/pull/654)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/dashboards-maps/compare/2.16...2.x)
 ### Features
 * Use new header to maps listing page [#653](https://github.com/opensearch-project/dashboards-maps/pull/653)
+* Use new header to maps visualization page [#654](https://github.com/opensearch-project/dashboards-maps/pull/654)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/public/components/map_top_nav/get_top_nav_config.tsx
+++ b/public/components/map_top_nav/get_top_nav_config.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { TopNavMenuData } from '../../../../../src/plugins/navigation/public';
+import { TopNavMenuData, TopNavMenuIconData } from '../../../../../src/plugins/navigation/public';
 import {
   SavedObjectSaveModalOrigin,
   showSaveModal,
@@ -25,6 +25,7 @@ interface GetTopNavConfigParams {
   setDescription: (description: string) => void;
   mapState: MapState;
   originatingApp?: string;
+  showActionsInGroup: boolean;
 }
 
 export const getTopNavConfig = (
@@ -38,6 +39,7 @@ export const getTopNavConfig = (
     setDescription,
     mapState,
     originatingApp,
+    showActionsInGroup,
   }: GetTopNavConfigParams
 ) => {
   const {
@@ -46,6 +48,51 @@ export const getTopNavConfig = (
     scopedHistory,
   } = services;
   const stateTransfer = embeddable.getStateTransfer(scopedHistory);
+  const onSaveButtonClick = () => {
+    const documentInfo = {
+      title,
+      description,
+    };
+    const saveModal = (
+      <SavedObjectSaveModalOrigin
+        documentInfo={documentInfo}
+        onSave={onGetSave(
+          title,
+          originatingApp,
+          mapIdFromUrl,
+          services,
+          layers,
+          mapState,
+          setTitle,
+          setDescription
+        )}
+        objectType={'map'}
+        onClose={() => {}}
+        originatingApp={originatingApp}
+        getAppNameFromId={stateTransfer.getAppNameFromId}
+      />
+    );
+    showSaveModal(saveModal, I18nContext);
+  };
+
+  if (showActionsInGroup) {
+    const topNavConfig: TopNavMenuIconData[] = [
+      {
+        tooltip: i18n.translate('maps.topNav.saveMapButtonLabel', {
+          defaultMessage: `Save`,
+        }),
+        ariaLabel: i18n.translate('maps.topNav.saveButtonAriaLabel', {
+          defaultMessage: 'Save your map',
+        }),
+        testId: 'mapSaveButton',
+        run: onSaveButtonClick,
+        iconType: 'save',
+        controlType: 'icon',
+      },
+    ];
+    return topNavConfig;
+  }
+
   const topNavConfig: TopNavMenuData[] = [
     {
       iconType: 'save',
@@ -55,33 +102,7 @@ export const getTopNavConfig = (
         defaultMessage: `Save`,
       }),
       testId: 'mapSaveButton',
-      run: (_anchorElement: any) => {
-        const documentInfo = {
-          title,
-          description,
-        };
-
-        const saveModal = (
-          <SavedObjectSaveModalOrigin
-            documentInfo={documentInfo}
-            onSave={onGetSave(
-              title,
-              originatingApp,
-              mapIdFromUrl,
-              services,
-              layers,
-              mapState,
-              setTitle,
-              setDescription
-            )}
-            objectType={'map'}
-            onClose={() => {}}
-            originatingApp={originatingApp}
-            getAppNameFromId={stateTransfer.getAppNameFromId}
-          />
-        );
-        showSaveModal(saveModal, I18nContext);
-      },
+      run: onSaveButtonClick,
     },
   ];
   return topNavConfig;

--- a/public/components/map_top_nav/top_nav_menu.tsx
+++ b/public/components/map_top_nav/top_nav_menu.tsx
@@ -15,6 +15,8 @@ import { getSavedMapBreadcrumbs } from '../../utils/breadcrumbs';
 import { handleDataLayerRender } from '../../model/layerRenderController';
 import { MapLayerSpecification } from '../../model/mapLayerType';
 import { MapState } from '../../model/mapState';
+import { HeaderVariant } from '../../../../../src/core/public';
+import { TopNavMenuItemRenderType } from '../../../../../src/plugins/navigation/public';
 
 interface MapTopNavMenuProps {
   mapIdFromUrl: string;
@@ -48,6 +50,7 @@ export const MapTopNavMenu = ({
     application: { navigateToApp },
     embeddable,
     scopedHistory,
+    uiSettings,
   } = services;
 
   const [title, setTitle] = useState<string>('');
@@ -65,6 +68,17 @@ export const MapTopNavMenu = ({
     },
     [chrome, navigateToApp]
   );
+  const showActionsInGroup = uiSettings.get('home:useNewHomePage');
+
+  useEffect(() => {
+    if (showActionsInGroup) {
+      chrome.setHeaderVariant?.(HeaderVariant.APPLICATION);
+    }
+
+    return () => {
+      chrome.setHeaderVariant?.();
+    };
+  }, [chrome.setHeaderVariant, showActionsInGroup]);
 
   useEffect(() => {
     const { originatingApp: value } =
@@ -129,6 +143,7 @@ export const MapTopNavMenu = ({
       setDescription,
       mapState,
       originatingApp,
+      showActionsInGroup,
     });
   }, [services, mapIdFromUrl, layers, title, description, mapState, originatingApp]);
 
@@ -139,7 +154,7 @@ export const MapTopNavMenu = ({
       config={config}
       setMenuMountPoint={setHeaderActionMenu}
       indexPatterns={layersIndexPatterns || []}
-      showSearchBar={true}
+      showSearchBar={TopNavMenuItemRenderType.IN_PORTAL}
       showFilterBar={false}
       showDatePicker={true}
       showQueryBar={true}
@@ -153,6 +168,8 @@ export const MapTopNavMenu = ({
       refreshInterval={refreshIntervalValue}
       onRefresh={refreshDataLayerRender}
       onRefreshChange={onRefreshChange}
+      groupActions={showActionsInGroup}
+      screenTitle={title}
     />
   );
 };


### PR DESCRIPTION
### Description
This PR apply the new header UI in Maps visualization page when `home:useNewHomePage` is enabled.

Will add integ tests for new header UI in separate PR.

### Screenshot
#### When `home:useNewHomePage` is NOT enabled(Default)
<img width="2539" alt="Screenshot 2024-08-12 at 1 54 43 PM" src="https://github.com/user-attachments/assets/334ee2f9-057e-4e29-8161-9eb0fd24c66b">

#### When `home:useNewHomePage` is enabled

<img width="2535" alt="Screenshot 2024-08-12 at 2 29 39 PM" src="https://github.com/user-attachments/assets/e6f414c1-7061-411d-9166-83e1bc48b0ab">

### Issues Resolved
Part of https://github.com/opensearch-project/dashboards-maps/issues/649

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
