### PR TITLE
Conditionally use full width for Maps listing page table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * Conditionally use the new Page Header variant on the Maps listing page [#653](https://github.com/opensearch-project/dashboards-maps/pull/653)
 * Conditionally use the new Application Header variant on the Maps visualization page [#654](https://github.com/opensearch-project/dashboards-maps/pull/654)
+* Conditionally use full width for Maps listing page table [#655](https://github.com/opensearch-project/dashboards-maps/pull/655)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/public/components/maps_list/maps_list.tsx
+++ b/public/components/maps_list/maps_list.tsx
@@ -7,9 +7,6 @@ import { i18n } from '@osd/i18n';
 import React, { useCallback, useEffect } from 'react';
 import { I18nProvider } from '@osd/i18n/react';
 import {
-  EuiPage,
-  EuiPageBody,
-  EuiPageContentBody,
   EuiLink,
   EuiSmallButton,
   EuiPageHeader,
@@ -38,7 +35,7 @@ export const MapsList = () => {
     },
   } = useOpenSearchDashboards<MapServices>();
 
-  const showActionsInHeader = uiSettings.get('home:useNewHomePage');
+  const newHomePageEnabled = uiSettings.get('home:useNewHomePage');
 
     useEffect(() => {
     setBreadcrumbs(getMapsLandingBreadcrumbs(navigateToApp));
@@ -114,7 +111,7 @@ export const MapsList = () => {
       pageTitle="Create your first map"
       description="There is no map to display, let's create your first map."
       rightSideItems={
-        showActionsInHeader ? [] : [
+        newHomePageEnabled ? [] : [
           <EuiSmallButton
             fill
             onClick={navigateToCreateMapPage}
@@ -128,49 +125,46 @@ export const MapsList = () => {
   );
 
   return (
+    // @ts-ignore
     <I18nProvider>
       <>
-        <EuiPage restrictWidth="1000px">
-          <EuiPageBody component="main" data-test-subj="mapListingPage">
-            <EuiPageContentBody>
-              {showActionsInHeader &&
-                <HeaderControl
-                  setMountPoint={application.setAppRightControls}
-                  controls={[
-                    {
-                      id: 'Create map',
-                      label: 'Create map',
-                      iconType: 'plus',
-                      fill: true,
-                      href: `${MAPS_APP_ID}${APP_PATH.CREATE_MAP}`,
-                      testId: 'createButton',
-                      controlType: 'button',
-                    },
-                  ]}
-                />}
-              <TableListView
-                headingId="mapsListingHeading"
-                createItem= { showActionsInHeader ? undefined : navigateToCreateMapPage }
-                findItems={fetchMaps}
-                deleteItems={deleteMaps}
-                tableColumns={tableColumns}
-                listingLimit={10}
-                initialPageSize={10}
-                initialFilter={''}
-                noItemsFragment={noMapItem}
-                entityName={i18n.translate('maps.listing.table.entityName', {
-                  defaultMessage: 'map',
-                })}
-                entityNamePlural={i18n.translate('maps.listing.table.entityNamePlural', {
-                  defaultMessage: 'maps',
-                })}
-                tableListTitle={showActionsInHeader ? '' : i18n.translate('maps.listing.table.listTitle', {
-                  defaultMessage: 'Maps'})}
-                toastNotifications={notifications.toasts}
-              />
-            </EuiPageContentBody>
-          </EuiPageBody>
-        </EuiPage>
+        {newHomePageEnabled &&
+          // @ts-ignore
+          <HeaderControl
+            setMountPoint={application.setAppRightControls}
+            controls={[
+              {
+                id: 'Create map',
+                label: 'Create map',
+                iconType: 'plus',
+                fill: true,
+                href: `${MAPS_APP_ID}${APP_PATH.CREATE_MAP}`,
+                testId: 'createButton',
+                controlType: 'button',
+              },
+            ]}
+          />}
+        <TableListView
+          headingId="mapsListingHeading"
+          createItem= { newHomePageEnabled ? undefined : navigateToCreateMapPage }
+          findItems={fetchMaps}
+          deleteItems={deleteMaps}
+          tableColumns={tableColumns}
+          listingLimit={10}
+          initialPageSize={10}
+          initialFilter={''}
+          noItemsFragment={noMapItem}
+          entityName={i18n.translate('maps.listing.table.entityName', {
+            defaultMessage: 'map',
+          })}
+          entityNamePlural={i18n.translate('maps.listing.table.entityNamePlural', {
+            defaultMessage: 'maps',
+          })}
+          tableListTitle={newHomePageEnabled ? '' : i18n.translate('maps.listing.table.listTitle', {
+            defaultMessage: 'Maps'})}
+          toastNotifications={notifications.toasts}
+          restrictWidth={newHomePageEnabled ? false : true}
+        />
       </>
     </I18nProvider>
   );


### PR DESCRIPTION
### Description
Since https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7691 merged(thanks @AMoo-Miki), this PR allows conditionally use full width for Maps listing page table when new home page UI is enabled.

### Screenshot
#### When new home page UI is NOT enabled(default)
<img width="1491" alt="Screenshot 2024-08-14 at 11 20 52 AM" src="https://github.com/user-attachments/assets/880e5745-f5de-401b-930a-2f4ddf2f71d3">

#### When new home page UI is enabled
<img width="1492" alt="Screenshot 2024-08-14 at 11 22 35 AM" src="https://github.com/user-attachments/assets/495fd68d-0e86-49b5-bf78-6e10e869f182">


### Issues Resolved
Part of #649 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
