### PR TITLE
[Look & Feel] Consistency and Density Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 * Deprecated maps multi data source display [#651](https://github.com/opensearch-project/dashboards-maps/pull/651)
 ### Refactoring
+* Consistency and Desntiy changes [#659] (https://github.com/opensearch-project/dashboards-maps/pull/659)

--- a/public/components/__snapshots__/vector_upload_options.test.tsx.snap
+++ b/public/components/__snapshots__/vector_upload_options.test.tsx.snap
@@ -206,7 +206,7 @@ Object {
               >
                 <button
                   aria-label="import-file-button"
-                  class="euiButton euiButton--primary euiButton--small euiButton--fill"
+                  class="euiButton euiButton--primary euiButton--small"
                   id="submitButton"
                   type="button"
                 >
@@ -429,7 +429,7 @@ Object {
             >
               <button
                 aria-label="import-file-button"
-                class="euiButton euiButton--primary euiButton--small euiButton--fill"
+                class="euiButton euiButton--primary euiButton--small"
                 id="submitButton"
                 type="button"
               >

--- a/public/components/add_layer_panel/add_layer_panel.tsx
+++ b/public/components/add_layer_panel/add_layer_panel.tsx
@@ -124,11 +124,11 @@ export const AddLayerPanel = ({
           <EuiButton
             fullWidth
             size="s"
-            fill
             onClick={showModal}
             aria-label="Add layer"
             isDisabled={IsLayerConfigVisible || isMaxLayerLimitReached()}
             data-test-subj="addLayerButton"
+            iconType="plusInCircle"
           >
             Add layer
           </EuiButton>
@@ -138,7 +138,9 @@ export const AddLayerPanel = ({
         <EuiModal onClose={closeModal}>
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <h2>Add layer</h2>
+              <EuiText size="s">
+                <h2>Add layer</h2>
+              </EuiText>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody className="addLayer__modalBody">
@@ -159,7 +161,7 @@ export const AddLayerPanel = ({
                 <EuiTitle size="s">
                   <h6>{highlightItem?.name ? highlightItem.name : 'Select a layer type'}</h6>
                 </EuiTitle>
-                <EuiText>
+                <EuiText size="s">
                   {highlightItem?.description
                     ? highlightItem.description
                     : 'Start creating your map by selecting a layer type.'}

--- a/public/components/filter_bar/filter_item.tsx
+++ b/public/components/filter_bar/filter_item.tsx
@@ -173,7 +173,7 @@ export function FilterItem({ filterMeta, onUpdate, onRemove, id, className }: Pr
       anchorPosition="downLeft"
       panelPaddingSize="none"
     >
-      <EuiContextMenu initialPanelId={0} panels={getPanels()} />
+      <EuiContextMenu initialPanelId={0} panels={getPanels()} size="s" />
     </EuiPopover>
   );
 }

--- a/public/components/filter_bar/filter_options.tsx
+++ b/public/components/filter_bar/filter_options.tsx
@@ -120,7 +120,7 @@ export const FilterOptions = ({
           defaultMessage: 'Change all filters',
         })}
       </EuiPopoverTitle>
-      <EuiContextMenu initialPanelId={0} panels={[panelTree]} />
+      <EuiContextMenu initialPanelId={0} panels={[panelTree]} size="s"/>
     </EuiPopover>
   );
 };

--- a/public/components/layer_config/base_map_layer_config_panel.tsx
+++ b/public/components/layer_config/base_map_layer_config_panel.tsx
@@ -28,5 +28,5 @@ export const BaseMapLayerConfigPanel = (props: Props) => {
       ),
     },
   ];
-  return <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} />;
+  return <EuiTabbedContent tabs={tabs} size="s" initialSelectedTab={tabs[0]} />;
 };

--- a/public/components/layer_config/custom_map_config/custom_map_config_panel.tsx
+++ b/public/components/layer_config/custom_map_config/custom_map_config_panel.tsx
@@ -43,5 +43,5 @@ export const CustomMapConfigPanel = (props: Props) => {
       ),
     },
   ];
-  return <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} />;
+  return <EuiTabbedContent tabs={tabs} size="s" initialSelectedTab={tabs[0]} />;
 };

--- a/public/components/layer_config/documents_config/document_layer_config_panel.tsx
+++ b/public/components/layer_config/documents_config/document_layer_config_panel.tsx
@@ -85,5 +85,5 @@ export const DocumentLayerConfigPanel = (props: Props) => {
       testsubj: 'settingsTab',
     },
   ];
-  return <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} />;
+  return <EuiTabbedContent tabs={tabs} size="s" initialSelectedTab={tabs[0]} />;
 };

--- a/public/components/layer_config/layer_config_panel.tsx
+++ b/public/components/layer_config/layer_config_panel.tsx
@@ -22,6 +22,7 @@ import {
   EuiModalHeaderTitle,
   EuiIcon,
   EuiSpacer,
+  EuiText,
 } from '@elastic/eui';
 
 import { MapLayerSpecification } from '../../model/mapLayerType';
@@ -163,7 +164,7 @@ export const LayerConfigPanel = ({
           <EuiFlexItem grow={false}>
             <EuiSmallButton
               disabled={isUpdateDisabled}
-              iconType="play"
+              iconType="refresh"
               onClick={onUpdate}
               fill
               data-test-subj="updateButton"
@@ -176,10 +177,14 @@ export const LayerConfigPanel = ({
       {unsavedModalVisible && (
         <EuiModal onClose={closeModal}>
           <EuiModalHeader>
-            <EuiModalHeaderTitle>Unsaved changes</EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2><EuiModalHeaderTitle>Unsaved changes</EuiModalHeaderTitle></h2>
+            </EuiText>
           </EuiModalHeader>
           <EuiModalBody>
-            <p>Do you want to discard the changes?</p>
+            <EuiText size="s">
+              <p>Do you want to discard the changes?</p>
+            </EuiText>
           </EuiModalBody>
           <EuiModalFooter>
             <EuiSmallButtonEmpty onClick={closeModal}>Cancel</EuiSmallButtonEmpty>

--- a/public/components/layer_control_panel/delete_layer_modal.test.tsx
+++ b/public/components/layer_control_panel/delete_layer_modal.test.tsx
@@ -14,7 +14,8 @@ describe('test delete layer modal', function () {
       <DeleteLayerModal layerName={'test-layer'} onCancel={() => {}} onConfirm={() => {}} />
     );
     const testInstance = deleteLayerModal.root;
-    expect(testInstance.findByType(EuiConfirmModal).props.title).toBe('Delete layer');
+    //expect(testInstance.findByType(EuiConfirmModal).props.title).toBe('Delete layer');
+    expect(testInstance.findByType(EuiConfirmModal).props.title.props.children.props.children).toBe('Delete layer');
     expect(testInstance.findByType(EuiConfirmModal).props.confirmButtonText).toBe('Delete');
     expect(testInstance.findByType(EuiConfirmModal).props.cancelButtonText).toBe('Cancel');
     expect(testInstance.findByType(EuiConfirmModal).props.buttonColor).toBe('danger');

--- a/public/components/layer_control_panel/delete_layer_modal.tsx
+++ b/public/components/layer_control_panel/delete_layer_modal.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiConfirmModal } from '@elastic/eui';
+import { EuiConfirmModal, EuiText } from '@elastic/eui';
 import React from 'react';
 
 interface DeleteLayerModalProps {
@@ -14,7 +14,11 @@ interface DeleteLayerModalProps {
 export const DeleteLayerModal = ({ onCancel, onConfirm, layerName }: DeleteLayerModalProps) => {
   return (
     <EuiConfirmModal
-      title="Delete layer"
+      title={
+        <EuiText size="s">
+          <h2>Delete layer</h2>
+        </EuiText>
+      }
       onCancel={onCancel}
       onConfirm={onConfirm}
       cancelButtonText="Cancel"
@@ -22,9 +26,11 @@ export const DeleteLayerModal = ({ onCancel, onConfirm, layerName }: DeleteLayer
       buttonColor="danger"
       defaultFocusedButton="confirm"
     >
-      <p>
-        Do you want to delete layer <strong>{layerName}</strong>?
-      </p>
+      <EuiText size="s">
+        <p>
+          Do you want to delete layer <strong>{layerName}</strong>?
+        </p>
+      </EuiText>
     </EuiConfirmModal>
   );
 };

--- a/public/components/layer_control_panel/layer_control_panel.tsx
+++ b/public/components/layer_control_panel/layer_control_panel.tsx
@@ -316,6 +316,7 @@ export const LayerControlPanel = memo(
                               <EuiFlexItem>
                                 <EuiToolTip position="top" content={getLayerTooltipContent(layer)}>
                                   <EuiListGroupItem
+                                    size="s"
                                     key={layer.id}
                                     label={layer.name}
                                     color={layerIsVisible(layer) ? 'text' : 'subdued'}

--- a/public/components/map_container/maps_messages.tsx
+++ b/public/components/map_container/maps_messages.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiLink } from '@elastic/eui';
+import { EuiLink, EuiText } from '@elastic/eui';
 import React from 'react';
 import { ToastInputFields } from '../../../../../src/core/public';
 import { toMountPoint } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 
 export const MapsServiceErrorMsg: ToastInputFields = {
   title: 'The OpenSearch Maps Service is currently not available in your region',
-  text: toMountPoint(
+  text: toMountPoint( 
     <p>
       You can configure OpenSearch Dashboards to use a{' '}
       <EuiLink

--- a/public/components/maps_list/maps_list.tsx
+++ b/public/components/maps_list/maps_list.tsx
@@ -116,6 +116,7 @@ export const MapsList = () => {
             fill
             onClick={navigateToCreateMapPage}
             data-test-subj="createFirstMapButton"
+            iconType="plus"
           >
             Create map
           </EuiSmallButton>

--- a/public/components/show_error_modal.tsx
+++ b/public/components/show_error_modal.tsx
@@ -13,6 +13,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiCodeBlock,
+  EuiText,
 } from '@elastic/eui';
 
 export interface ShowErrorModalProps {
@@ -34,7 +35,9 @@ const ShowErrorModal = (props: ShowErrorModalProps) => {
       <EuiModal onClose={closeModal}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <h1>{props.modalTitle}</h1>
+            <EuiText size="s">
+              <h2>{props.modalTitle}</h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
@@ -48,7 +51,6 @@ const ShowErrorModal = (props: ShowErrorModalProps) => {
             aria-label="closeModal"
             data-testid="closeModal"
             onClick={closeModal}
-            fill
           >
             Close
           </EuiSmallButton>

--- a/public/components/toolbar/spatial_filter/display_draw_helper.tsx
+++ b/public/components/toolbar/spatial_filter/display_draw_helper.tsx
@@ -52,7 +52,7 @@ export const DrawFilterShapeHelper = memo(({ map, mode, onCancel }: DrawFilterSh
           <small>{getHelpText(mode)}</small>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton fill onClick={onCancel} size={'s'}>
+          <EuiButton onClick={onCancel} size={'s'}>
             {'Cancel'}
           </EuiButton>
         </EuiFlexItem>

--- a/public/components/toolbar/spatial_filter/filter_by_shape.tsx
+++ b/public/components/toolbar/spatial_filter/filter_by_shape.tsx
@@ -101,7 +101,7 @@ export const FilterByShape = ({
       anchorPosition="leftUp"
       data-test-subj="drawShapePopOver"
     >
-      <EuiContextMenu initialPanelId={0} panels={panels} />
+      <EuiContextMenu initialPanelId={0} panels={panels} size="s" />
     </EuiPopover>
   );
 };

--- a/public/components/toolbar/spatial_filter/filter_input_panel.tsx
+++ b/public/components/toolbar/spatial_filter/filter_input_panel.tsx
@@ -80,7 +80,6 @@ export const FilterInputPanel = ({
           <EuiButton
             fullWidth
             size="s"
-            fill
             aria-label={drawLabel}
             data-test-subj="add-draw-button"
             onClick={updateSpatialFilterProperties}

--- a/public/components/vector_upload_options.tsx
+++ b/public/components/vector_upload_options.tsx
@@ -395,7 +395,6 @@ const VectorUploadOptions = (props: RegionMapOptionsProps) => {
           <EuiSmallButton
             id="submitButton"
             type="button"
-            fill
             onClick={handleSubmit}
             isLoading={isLoading}
             aria-label="import-file-button"


### PR DESCRIPTION
## Description

This PR makes consistency and density improvements, including:

1. Using small context menus
2. Using small tabs
3. Using small List Groups
4. Using small font size as normal paragraph font size through 
5. Using semantic headers (H1s on main pages, H2s on modals/flyouts) wrapped under 
6. Only using primary buttons for primary calls to action.
7. Using Plus icons for create use cases and PlusInCricle icon for add use cases.
8. Use Refresh Icon in “Update” buttons


## Screenshots

### Small Context Menus
|     Before        |       After        |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-08-20 at 4 35 52 PM" src="https://github.com/user-attachments/assets/a4a8e573-0654-45f6-9f7f-6c9e7fde3993"> | <img width="300" alt="Screenshot 2024-08-20 at 4 36 16 PM" src="https://github.com/user-attachments/assets/e0c08dd6-661d-43f3-940c-0d9ac81f4984"> |

### Small Tabs
|     Before        |       After        |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-08-20 at 4 37 14 PM" src="https://github.com/user-attachments/assets/7d6a0271-a3d6-4768-a1ef-0411e5249f8a"> | <img width="300" alt="Screenshot 2024-08-20 at 4 37 53 PM" src="https://github.com/user-attachments/assets/e1e1a534-4944-4abb-a1d7-94066fa546d1"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 38 31 PM" src="https://github.com/user-attachments/assets/4d83959a-e709-4474-ae86-68acf679c890"> | <img width="300" alt="Screenshot 2024-08-20 at 4 38 49 PM" src="https://github.com/user-attachments/assets/d31ec741-ff83-42f3-9ad2-c78eb66afa1d"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 39 10 PM" src="https://github.com/user-attachments/assets/74bafef0-d84b-4f1f-8b4b-b275a97a4098"> | <img width="300" alt="Screenshot 2024-08-20 at 4 39 26 PM" src="https://github.com/user-attachments/assets/6129cc08-d907-4bba-81d3-36ee080560e6"> |

###  Small List Groups
|     Before        |       After        |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-08-20 at 4 40 33 PM" src="https://github.com/user-attachments/assets/c5723cc0-0b69-4a87-8a2d-a8b87bbab157"> | <img width="300" alt="Screenshot 2024-08-20 at 4 41 00 PM" src="https://github.com/user-attachments/assets/8ee0db7e-df75-4d1f-9a73-0aaa4565b010"> |

### Standard Paragraph Text Size
|     Before        |       After        |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-08-20 at 4 41 41 PM" src="https://github.com/user-attachments/assets/b60228e2-f421-4ad2-a4c6-4f0a6fc3c2c6"> | <img width="300" alt="Screenshot 2024-08-20 at 4 42 12 PM" src="https://github.com/user-attachments/assets/728a7ca0-c971-445f-9af8-188cc6493169"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 44 48 PM" src="https://github.com/user-attachments/assets/8c333538-bc3a-4e8b-8e57-dc301c7b5135"> | <img width="300" alt="Screenshot 2024-08-20 at 4 45 09 PM" src="https://github.com/user-attachments/assets/d5acf78a-146e-4e23-a628-026ebe3dc553"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 45 29 PM" src="https://github.com/user-attachments/assets/490c1bd9-1363-4029-861a-eabd9f865c0d"> | <img width="300" alt="Screenshot 2024-08-20 at 4 45 46 PM" src="https://github.com/user-attachments/assets/36b5f0aa-aa1a-4bd0-994c-3396a939e932"> |

### Semantic Headers
|     Before        |       After        |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-08-20 at 4 48 14 PM" src="https://github.com/user-attachments/assets/5d029c73-a916-493c-b1dc-e121d7466bc6"> | <img width="300" alt="Screenshot 2024-08-20 at 4 48 41 PM" src="https://github.com/user-attachments/assets/d937c907-86c6-45a3-9e69-83c862b07e9d"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 49 35 PM" src="https://github.com/user-attachments/assets/8f587de6-68c1-4b9e-b02b-3fd00fa77163"> | <img width="300" alt="Screenshot 2024-08-20 at 4 49 50 PM" src="https://github.com/user-attachments/assets/7ee41af2-6b4e-42a4-bba2-e4d371d9e31d"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 50 08 PM" src="https://github.com/user-attachments/assets/d1536937-3681-4a89-9028-c5a9a43782c6"> | <img width="300" alt="Screenshot 2024-08-20 at 4 50 24 PM" src="https://github.com/user-attachments/assets/c03379c4-ec94-43c4-a924-9d2bd0e567a9"> | 

### Buttons for Actions
|     Before        |       After        |
| ------------- | ------------- |
| <img width="1113" alt="Screenshot 2024-08-20 at 4 51 44 PM" src="https://github.com/user-attachments/assets/e73d28d6-ffde-4ee5-bb19-b7ae9dee9e41"> | <img width="1108" alt="Screenshot 2024-08-20 at 4 52 09 PM" src="https://github.com/user-attachments/assets/31edb43d-70d6-48b6-8eec-98851b7dc06b"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 52 55 PM" src="https://github.com/user-attachments/assets/d345560c-e4e7-4eee-a049-ac9e656c4d64"> | <img width="300" alt="Screenshot 2024-08-20 at 4 53 07 PM" src="https://github.com/user-attachments/assets/cbe955a9-2a7a-43a5-afc2-66bb491dc707"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 53 40 PM" src="https://github.com/user-attachments/assets/b478f618-f96e-44bf-ab9e-ddd51368718a"> | <img width="300" alt="Screenshot 2024-08-20 at 4 53 55 PM" src="https://github.com/user-attachments/assets/2cb9b99b-c0ee-459d-b136-6ecade45199b"> | 
| <img width="300" alt="Screenshot 2024-08-20 at 4 55 41 PM" src="https://github.com/user-attachments/assets/1ea883db-d75c-4069-8691-b722367e5e1c"> | <img width="300" alt="Screenshot 2024-08-20 at 4 56 00 PM" src="https://github.com/user-attachments/assets/17b9abd8-78a4-4d65-b065-d3a0879b71f7"> | 

### Plus Icon and PlusInCircle Icon
|     Before        |       After        |
| ------------- | ------------- |
| <img width="1188" alt="Screenshot 2024-08-20 at 4 57 06 PM" src="https://github.com/user-attachments/assets/f251b1d3-ba4f-43e1-8d0b-21edf8de8b39"> | <img width="1221" alt="Screenshot 2024-08-20 at 4 57 25 PM" src="https://github.com/user-attachments/assets/333932bf-4391-4d51-8711-e0f3c442f0f0"> |
| <img width="300" alt="Screenshot 2024-08-20 at 4 57 44 PM" src="https://github.com/user-attachments/assets/a5b6cf2d-ea48-4a6f-9ad2-5590a2f7c71f"> | <img width="300" alt="Screenshot 2024-08-20 at 4 58 00 PM" src="https://github.com/user-attachments/assets/953a75a1-596f-426d-8992-c19fd8ad51f4"> | 

###  Refresh Icon in “Update” Buttons
|     Before        |       After        |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2024-08-20 at 4 58 50 PM" src="https://github.com/user-attachments/assets/a5098cd5-9ace-41b7-b601-cc201afa2dcf"> | <img width="300" alt="Screenshot 2024-08-20 at 4 59 04 PM" src="https://github.com/user-attachments/assets/4de403e3-2bd5-49e1-9c2a-50fff59a621f">


## Changelog
- refactor: [Look & Feel] Appearance Popover Button Change 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
