### PR TITLE
[navigation]feat: update category to flatten menus in analytics(all) use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/dashboards-maps/compare/2.17...2.x)
 ### Features
+* [navigation]feat: update category to flatten menus in analytics(all) use case [#674](https://github.com/opensearch-project/dashboards-maps/pull/674)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -104,6 +104,16 @@ export class CustomImportMapPlugin
       category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
       order: 200,
     }]);
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [{
+      id: MAPS_APP_ID,
+      category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
+      order: 200,
+    }]);
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.all, [{
+      id: MAPS_APP_ID,
+      category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
+      order: 200,
+    }]);
 
     const mapEmbeddableFactory = new MapEmbeddableFactoryDefinition(async () => {
       const [coreStart, depsStart] = await core.getStartServices();


### PR DESCRIPTION
### Description

Based on https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8332, maps needs to make some adjustment to flatten the menus in analytics(all) use case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
