### PR TITLE
fix: prevent overlay from overlapping new application header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [navigation]feat: update category to flatten menus in analytics(all) use case [#674](https://github.com/opensearch-project/dashboards-maps/pull/674)
 ### Enhancements
 ### Bug Fixes
+* fix: prevent overlay from overlapping new application header
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/public/components/layer_config/layer_config_panel.tsx
+++ b/public/components/layer_config/layer_config_panel.tsx
@@ -107,6 +107,9 @@ export const LayerConfigPanel = ({
       onClose={onClose}
       hideCloseButton={true}
       className="layerConfigPanel"
+      // Flyout starts to overlap app header under this breakpoint, likely need
+      // to convert this to a panel considering the new layout.
+      pushMinBreakpoint={1576}
     >
       <EuiFlyoutHeader hasBorder={true}>
         <EuiFlexGroup gutterSize="s" alignItems="center">


### PR DESCRIPTION
### Description
Currently, the layers right pane was designed with the older header in mind, and pushed the page content to the left. The new page header isn't build for a static right pane, and because it is no longer fixed height, it is difficult to move the pushed flyout underneath it without things looking weird. Ideally, this flight was moved to become a panel, but to fix this bug in the short term, this just forces the flyout into overlay mode at the window width it starts creating problems.

Under this new breakpoint (1576, used to be 992), the experience looks like 
![image](https://github.com/user-attachments/assets/0cd72dd3-dce1-48f7-b829-1458f066b6d2)

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
