### PR TITLE
Fix layer config panel background color inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fix layer config panel background color inconsistency ([#704](https://github.com/opensearch-project/dashboards-maps/pull/704))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/public/index.scss
+++ b/public/index.scss
@@ -2,3 +2,20 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
+// Override EuiCollapsibleNavGroup background color
+.layerConfigPanel {
+  .euiCollapsibleNavGroup {
+    background: transparent;
+
+    // Remove any background color on hover if it exists
+    &:hover {
+      background: transparent;
+    }
+
+    // Ensure the content area is also transparent
+    .euiCollapsibleNavGroup__content {
+      background: transparent;
+    }
+  }
+}


### PR DESCRIPTION
### Description

The current document layer configuration panels had a grey background due to EuiCollapsibleNavGroup's default styling.

Added CSS override to make EuiCollapsibleNavGroup backgrounds transparent within the layer config panel, ensuring consistent styling across all layer type configurations. It can be applied to other layer type panels as well which need EuiCollapsibleNavGroup.

### Screenshot
#### Before fix
<img width="420" alt="Screenshot 2025-02-14 at 11 08 48 AM" src="https://github.com/user-attachments/assets/05abc022-1e25-44f1-b453-25675a307994" />

#### After fix

<img width="397" alt="Screenshot 2025-02-14 at 11 43 38 AM" src="https://github.com/user-attachments/assets/b872fd33-61f8-478a-a9c5-b1ed51be69e9" />


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
