### PR TITLE
Fix text overlap on symbol layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fix overlapping data labels on map layer ([#718](https://github.com/opensearch-project/dashboards-maps/pull/718))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/public/model/map/layer_operations.ts
+++ b/public/model/map/layer_operations.ts
@@ -302,7 +302,6 @@ export const updateSymbolLayer = (
   map.setLayoutProperty(symbolLayerId, 'text-size', specification.textSize);
   map.setPaintProperty(symbolLayerId, 'text-halo-width', specification.symbolBorderWidth);
   map.setPaintProperty(symbolLayerId, 'text-halo-color', specification.symbolBorderColor);
-  map.setLayoutProperty(symbolLayerId, 'text-allow-overlap', true);
   return symbolLayerId;
 };
 


### PR DESCRIPTION
### Description
Fixes label overlap issue. Previously with lots of documents, the default text overlap behavior prevented overlapping labels. [This line](https://github.com/opensearch-project/dashboards-maps/blob/494ea33b5ee27fcb9420141c2885751a914a1fb9/public/model/map/layer_operations.ts#L305) was introduced in #703 and allowed label overlapping, resulting in situations like the following. This reverts this overlapping behavior.

See https://maplibre.org/maplibre-style-spec/layers/#text-allow-overlap for documentation

Pre-3.0:
![Pasted image 20250414115509](https://github.com/user-attachments/assets/aa96e610-8ccb-466e-aee8-6e77bd7bbe74)

3.0:
![Pasted image 20250414135255](https://github.com/user-attachments/assets/2d2cb23c-540d-4c02-a33b-8f5abd01dc7e)

post fix:
![Pasted image 20250414135232](https://github.com/user-attachments/assets/d8a40775-1184-4561-b37b-1df1b3f38160)

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
