### PR TITLE
Fix workflow to use 3.5 branch for OpenSearch Dashboards

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -13,7 +13,7 @@ on:
       - feature/**
 
 env:
-  OPENSEARCH_DASHBOARDS_BRANCH: '3.5'
+  OPENSEARCH_DASHBOARDS_BRANCH: ${{ github.base_ref || github.ref_name }}
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main


### PR DESCRIPTION
## Description
This PR fixes the unit tests workflow failure in the 3.5 branch.

## Problem
The workflow was checking out the `main` branch of OpenSearch-Dashboards while testing against the `3.5` branch of dashboards-maps, causing compatibility issues during bootstrap.

## Solution
Updated `OPENSEARCH_DASHBOARDS_BRANCH` environment variable from `'main'` to `'3.5'` to match the target branch.

## Related Issues
Fixes the workflow failure in #792