### PR TITLE
Make workflow dynamically match target branch

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -13,7 +13,7 @@ on:
       - feature/**
 
 env:
-  OPENSEARCH_DASHBOARDS_BRANCH: 'main'
+  OPENSEARCH_DASHBOARDS_BRANCH: ${{ github.base_ref || github.ref_name }}
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main


### PR DESCRIPTION
## Description
This PR makes the unit tests workflow dynamically match the target branch for OpenSearch-Dashboards checkout.

## Problem
The workflow was hardcoded to check out the `main` branch of OpenSearch-Dashboards, causing compatibility issues when testing against other branches like 3.5, 2.x, etc.

## Solution
Updated `OPENSEARCH_DASHBOARDS_BRANCH` to use `${{ github.base_ref || github.ref_name }}`:
- For PRs: Uses `github.base_ref` (the target branch)
- For pushes: Uses `github.ref_name` (the current branch)

This ensures the workflow automatically uses the correct OpenSearch-Dashboards version for any branch.

## Related Issues
Fixes the workflow failure in #792