### PR TITLE
fix: Filter by map extent ignored for geo_shape fields (#796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+* Fixed filter by map extent ignored for geo_shape fields [798](https://github.com/opensearch-project/dashboards-maps/pull/798)
 
 ### Infrastructure
 

--- a/public/model/layerRenderController.ts
+++ b/public/model/layerRenderController.ts
@@ -221,7 +221,7 @@ const getGeoBoundingBoxFilter = (
     alias: null,
     disabled:
       !mapLayer.source.useGeoBoundingBoxFilter ||
-      (mapLayer.type === DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS && geoFieldType !== 'geo_point'),
+      (mapLayer.type === DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS && !['geo_point', 'geo_shape'].includes(geoFieldType)),
     negate: false,
     type: FILTERS.GEO_BOUNDING_BOX,
   };


### PR DESCRIPTION
### Description
This PR offers a fix for #796 .
According to the linked issue, for geo_shape fields, the map extent filter is disabled which causes the filter to not work for geo_shape fields. This commit includes geo_shape fields as allowed fields to enable this filter.


### Issues Resolved
#796 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
