### PR TITLE
[Navigation] Use getIsIconSideNavEnabled API for nav registration gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 
 ### Enhancements
+- Use `getIsIconSideNavEnabled` API for icon side nav registration gating ([#814](https://github.com/opensearch-project/dashboards-maps/pull/814))
 
 ### Bug Fixes
 

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -99,11 +99,14 @@ export class CustomImportMapPlugin
       },
     });
 
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [{
-      id: MAPS_APP_ID,
-      category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
-      order: 200,
-    }]);
+    const enableIconSideNav = core.uiSettings.get('home:enableIconSideNav', false);
+    if (!enableIconSideNav) {
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [{
+        id: MAPS_APP_ID,
+        category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
+        order: 200,
+      }]);
+    }
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [{
       id: MAPS_APP_ID,
       category: DEFAULT_APP_CATEGORIES.visualizeAndReport,

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -99,8 +99,7 @@ export class CustomImportMapPlugin
       },
     });
 
-    const enableIconSideNav = core.uiSettings.get('home:enableIconSideNav', false);
-    if (!enableIconSideNav) {
+    if (!core.chrome.getIsIconSideNavEnabled()) {
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [{
         id: MAPS_APP_ID,
         category: DEFAULT_APP_CATEGORIES.visualizeAndReport,

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { coreMock } from '../../../src/core/public/mocks';
-import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/public';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/utils';
 import { CustomImportMapPlugin } from './plugin';
 
 // Mock dynamic imports and dependencies

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -45,6 +45,9 @@ describe('CustomImportMapPlugin nav registration', () => {
   beforeEach(() => {
     coreSetup = coreMock.createSetup();
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    if (!coreSetup.chrome.getIsIconSideNavEnabled) {
+      coreSetup.chrome.getIsIconSideNavEnabled = jest.fn();
+    }
     const initializerContext = coreMock.createPluginInitializerContext();
     plugin = new CustomImportMapPlugin(initializerContext);
   });

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreMock } from '../../../src/core/public/mocks';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/public';
+import { CustomImportMapPlugin } from './plugin';
+
+// Mock dynamic imports and dependencies
+jest.mock('./application', () => ({
+  renderApp: jest.fn(() => jest.fn()),
+}));
+jest.mock('./embeddable', () => ({
+  MapEmbeddableFactoryDefinition: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock('../../../src/plugins/opensearch_dashboards_react/public', () => ({
+  OpenSearchDashboardsContextProvider: jest.fn(({ children }) => children),
+}));
+
+describe('CustomImportMapPlugin nav registration', () => {
+  let coreSetup: ReturnType<typeof coreMock.createSetup>;
+  let plugin: CustomImportMapPlugin;
+
+  const mockSetupDeps = {
+    regionMap: { addOptionTab: jest.fn() },
+    embeddable: { registerEmbeddableFactory: jest.fn() },
+    visualizations: {
+      registerAlias: jest.fn(),
+    },
+  } as any;
+
+  beforeEach(() => {
+    coreSetup = coreMock.createSetup();
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    const initializerContext = coreMock.createPluginInitializerContext();
+    plugin = new CustomImportMapPlugin(initializerContext);
+  });
+
+  it('should register maps in observability when icon side nav is disabled', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(false);
+
+    plugin.setup(coreSetup, mockSetupDeps);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    // When icon side nav is OFF, maps should be in observability
+    const observabilityCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS.observability &&
+        call[1].some(
+          (link: any) =>
+            link.id === 'maps-dashboards' &&
+            link.category === DEFAULT_APP_CATEGORIES.visualizeAndReport
+        )
+    );
+    expect(observabilityCall).toBeDefined();
+  });
+
+  it('should not register maps in observability when icon side nav is enabled', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    plugin.setup(coreSetup, mockSetupDeps);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    // When icon side nav is ON, maps should NOT be in observability
+    const observabilityCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS.observability &&
+        call[1].some((link: any) => link.id === 'maps-dashboards')
+    );
+    expect(observabilityCall).toBeUndefined();
+
+    // But should still be registered in search and all nav groups
+    const searchCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS.search &&
+        call[1].some((link: any) => link.id === 'maps-dashboards')
+    );
+    expect(searchCall).toBeDefined();
+
+    const allCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS.all &&
+        call[1].some((link: any) => link.id === 'maps-dashboards')
+    );
+    expect(allCall).toBeDefined();
+  });
+});

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -7,6 +7,18 @@ import { coreMock } from '../../../src/core/public/mocks';
 import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/utils';
 import { CustomImportMapPlugin } from './plugin';
 
+jest.mock('@osd/monaco', () => ({
+  monaco: {
+    languages: {
+      CompletionItemKind: { Function: 1, Field: 4, Module: 6, Operator: 12, Keyword: 14 },
+      CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+      registerCompletionItemProvider: jest.fn(),
+    },
+    editor: { create: jest.fn(), defineTheme: jest.fn() },
+    Range: jest.fn(),
+  },
+}));
+
 // Mock dynamic imports and dependencies
 jest.mock('./application', () => ({
   renderApp: jest.fn(() => jest.fn()),


### PR DESCRIPTION
## Summary

Migrates from reading the `home:enableIconSideNav` UI setting directly to using the new `core.chrome.getIsIconSideNavEnabled()` API. Maps are excluded from the Observability icon side nav and only registered in the default nav.

**Changes:**
- Replace `core.uiSettings.get('home:enableIconSideNav', false)` with `core.chrome.getIsIconSideNavEnabled()`
- Add unit tests covering both icon side nav enabled and disabled paths

**Files changed:**
- `public/plugin.tsx` — use `getIsIconSideNavEnabled()` API for nav gating
- `public/plugin_nav.test.ts` — new test file with coverage for both nav modes

## Related Issue

opensearch-project/OpenSearch-Dashboards#11545

## Test plan
- [ ] Verify maps do NOT appear in Observability icon side nav
- [ ] Verify maps appear under "Visualize and Report" in default Observability nav
- [ ] Run unit tests: `yarn test --testPathPattern=plugin_nav`