### PR TITLE
fix: hide AnalyticEngine data source index patterns from layer config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+- Hide AnalyticEngine data source index patterns from layer config dropdowns ([#825](https://github.com/opensearch-project/dashboards-maps/pull/825))
 
 ### Infrastructure
 

--- a/public/components/layer_config/cluster_config/data_source_section.tsx
+++ b/public/components/layer_config/cluster_config/data_source_section.tsx
@@ -3,16 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   EuiFormRow,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 import { IndexPattern } from '../../../../../../src/plugins/data/public';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { MapServices } from '../../../types';
 import { i18n } from '@osd/i18n';
 import { CanUpdateMapType } from './cluster_layer_source';
-import { useEffect } from 'react';
+import { useIndexPatternFilter } from '../../../utils/use_index_pattern_filter';
 
 interface Props {
   indexPattern: IndexPattern | null | undefined;
@@ -35,13 +36,22 @@ export const DataSourceSection = ({ indexPattern, setIndexPattern, setCanUpdateM
       },
     },
   } = useOpenSearchDashboards<MapServices>();
-  
+  const { filter: indexPatternFilter, loading: indexPatternFilterLoading } = useIndexPatternFilter(savedObjectsClient);
+
   useEffect(() => {
     setCanUpdateMap((prev) => ({
       ...prev,
       index: !!indexPattern,
     }));
   }, [indexPattern]);
+
+  if (indexPatternFilterLoading) {
+    return (
+      <EuiFormRow label="Index pattern" fullWidth>
+        <EuiLoadingSpinner size="m" />
+      </EuiFormRow>
+    );
+  }
 
   return (
     <EuiFormRow
@@ -64,6 +74,7 @@ export const DataSourceSection = ({ indexPattern, setIndexPattern, setCanUpdateM
         data-test-subj={'indexPatternSelect'}
         fullWidth={true}
         isInvalid={!indexPattern}
+        indexPatternFilter={indexPatternFilter}
       />
     </EuiFormRow>
   );

--- a/public/components/layer_config/documents_config/document_layer_source.tsx
+++ b/public/components/layer_config/documents_config/document_layer_source.tsx
@@ -18,6 +18,7 @@ import {
   EuiCheckbox,
   EuiCompressedFormRow,
   EuiFormRow,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
@@ -30,6 +31,7 @@ import {
   formatFieldsStringToComboBox,
   getFieldsOptions,
 } from '../../../utils/fields_options';
+import { useIndexPatternFilter } from '../../../utils/use_index_pattern_filter';
 
 interface Props {
   setSelectedLayerConfig: Function;
@@ -64,6 +66,7 @@ export const DocumentLayerSource = ({
       },
     },
   } = useOpenSearchDashboards<MapServices>();
+  const { filter: indexPatternFilter, loading: indexPatternFilterLoading } = useIndexPatternFilter(savedObjectsClient);
   const [hasInvalidRequestNumber, setHasInvalidRequestNumber] = useState<boolean>(false);
   const [enableTooltips, setEnableTooltips] = useState<boolean>(
     selectedLayerConfig.source.showTooltips
@@ -267,21 +270,26 @@ export const DocumentLayerSource = ({
             fullWidth
             data-test-subj={'indexPatternSelect'}
           >
-            <IndexPatternSelect
-              savedObjectsClient={savedObjectsClient}
-              placeholder={i18n.translate('documentLayer.selectDataSourcePlaceholder', {
-                defaultMessage: 'Select index pattern',
-              })}
-              indexPatternId={indexPattern?.id || ''}
-              onChange={async (newIndexPatternId: any) => {
-                const newIndexPattern = await indexPatterns.get(newIndexPatternId);
-                setIndexPattern(newIndexPattern);
-              }}
-              isClearable={false}
-              data-test-subj={'indexPatternSelect'}
-              fullWidth={true}
-              isInvalid={!indexPattern}
-            />
+            {indexPatternFilterLoading ? (
+              <EuiLoadingSpinner size="m" />
+            ) : (
+              <IndexPatternSelect
+                savedObjectsClient={savedObjectsClient}
+                placeholder={i18n.translate('documentLayer.selectDataSourcePlaceholder', {
+                  defaultMessage: 'Select index pattern',
+                })}
+                indexPatternId={indexPattern?.id || ''}
+                onChange={async (newIndexPatternId: any) => {
+                  const newIndexPattern = await indexPatterns.get(newIndexPatternId);
+                  setIndexPattern(newIndexPattern);
+                }}
+                isClearable={false}
+                data-test-subj={'indexPatternSelect'}
+                fullWidth={true}
+                isInvalid={!indexPattern}
+                indexPatternFilter={indexPatternFilter}
+              />
+            )}
           </EuiFormRow>
 
           <EuiSpacer size="s" />

--- a/public/utils/use_index_pattern_filter.test.ts
+++ b/public/utils/use_index_pattern_filter.test.ts
@@ -39,11 +39,8 @@ describe('useIndexPatternFilter', () => {
 
   it('filters out index patterns linked to blocked data sources', async () => {
     const client = createMockSavedObjectsClient([
-  const client = createMockSavedObjectsClient([
-    { id: 'ds-blocked', attributes: { dataSourceEngineType: 'AnalyticEngine' } },
-    { id: 'ds-allowed', attributes: { dataSourceEngineType: 'OpenSearch' } },
-  ]) as any;
-      { id: 'ds-allowed', attributes: { dataSourceEngineType: 'AnalyticEngine' } },
+      { id: 'ds-blocked', attributes: { dataSourceEngineType: 'AnalyticEngine' } },
+      { id: 'ds-allowed', attributes: { dataSourceEngineType: 'OpenSearch' } },
     ]) as any;
 
     const { result } = renderHook(() => useIndexPatternFilter(client));

--- a/public/utils/use_index_pattern_filter.test.ts
+++ b/public/utils/use_index_pattern_filter.test.ts
@@ -39,7 +39,10 @@ describe('useIndexPatternFilter', () => {
 
   it('filters out index patterns linked to blocked data sources', async () => {
     const client = createMockSavedObjectsClient([
-      { id: 'ds-blocked', attributes: { dataSourceEngineType: 'OpenSearch' } },
+  const client = createMockSavedObjectsClient([
+    { id: 'ds-blocked', attributes: { dataSourceEngineType: 'AnalyticEngine' } },
+    { id: 'ds-allowed', attributes: { dataSourceEngineType: 'OpenSearch' } },
+  ]) as any;
       { id: 'ds-allowed', attributes: { dataSourceEngineType: 'AnalyticEngine' } },
     ]) as any;
 

--- a/public/utils/use_index_pattern_filter.test.ts
+++ b/public/utils/use_index_pattern_filter.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useIndexPatternFilter } from './use_index_pattern_filter';
+
+describe('useIndexPatternFilter', () => {
+  const createMockSavedObjectsClient = (
+    dataSources: Array<{ id: string; attributes: { dataSourceEngineType?: string } }>
+  ) => ({
+    find: jest.fn().mockResolvedValue({
+      savedObjects: dataSources.map((ds) => ({
+        id: ds.id,
+        type: 'data-source',
+        attributes: ds.attributes,
+      })),
+    }),
+  });
+
+  it('reports loading state initially', () => {
+    const client = createMockSavedObjectsClient([]) as any;
+    const { result } = renderHook(() => useIndexPatternFilter(client));
+
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('reports loading false after fetch resolves', async () => {
+    const client = createMockSavedObjectsClient([]) as any;
+    const { result } = renderHook(() => useIndexPatternFilter(client));
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('filters out index patterns linked to blocked data sources', async () => {
+    const client = createMockSavedObjectsClient([
+      { id: 'ds-blocked', attributes: { dataSourceEngineType: 'OpenSearch' } },
+      { id: 'ds-allowed', attributes: { dataSourceEngineType: 'AnalyticEngine' } },
+    ]) as any;
+
+    const { result } = renderHook(() => useIndexPatternFilter(client));
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const { filter } = result.current;
+
+    // Index pattern referencing blocked data source
+    expect(
+      filter({
+        id: 'ip-1',
+        references: [{ type: 'data-source', id: 'ds-blocked' }],
+      } as any)
+    ).toBe(false);
+
+    // Index pattern referencing allowed data source
+    expect(
+      filter({
+        id: 'ip-2',
+        references: [{ type: 'data-source', id: 'ds-allowed' }],
+      } as any)
+    ).toBe(true);
+
+    // Index pattern with no data source reference (local cluster)
+    expect(
+      filter({
+        id: 'ip-3',
+        references: [],
+      } as any)
+    ).toBe(true);
+  });
+
+  it('allows all index patterns when fetch fails', async () => {
+    const client = {
+      find: jest.fn().mockRejectedValue(new Error('fetch failed')),
+    } as any;
+
+    const { result } = renderHook(() => useIndexPatternFilter(client));
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(
+      result.current.filter({
+        id: 'any-id',
+        references: [{ type: 'data-source', id: 'any-ds' }],
+      } as any)
+    ).toBe(true);
+  });
+});

--- a/public/utils/use_index_pattern_filter.ts
+++ b/public/utils/use_index_pattern_filter.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { SavedObjectsClientContract, SimpleSavedObject } from '../../../../src/core/public';
+
+const EXCLUDED_ENGINE_TYPES = ['AnalyticEngine'];
+
+/**
+ * Returns a synchronous filter function for IndexPatternSelect that excludes
+ * index patterns backed by unsupported data source engine types, along with a loading flag.
+ */
+export const useIndexPatternFilter = (
+  savedObjectsClient: SavedObjectsClientContract
+): { filter: (indexPattern: SimpleSavedObject<any>) => boolean; loading: boolean } => {
+  const [blockedDataSourceIds, setBlockedDataSourceIds] = useState<Set<string> | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    savedObjectsClient
+      .find<{ dataSourceEngineType?: string }>({ type: 'data-source', perPage: 10000 })
+      .then((response) => {
+        if (cancelled) return;
+        const blocked = new Set<string>();
+        for (const ds of response.savedObjects) {
+          if (
+            ds.attributes.dataSourceEngineType &&
+            EXCLUDED_ENGINE_TYPES.includes(ds.attributes.dataSourceEngineType)
+          ) {
+            blocked.add(ds.id);
+          }
+        }
+        setBlockedDataSourceIds(blocked);
+      })
+      .catch(() => {
+        // Fail-open: if fetch fails, allow all index patterns
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [savedObjectsClient]);
+
+  const filter = useCallback(
+    (indexPattern: SimpleSavedObject<any>) => {
+      if (!blockedDataSourceIds?.size) return true;
+      const dsRef = indexPattern.references?.find(
+        (ref: { type: string }) => ref.type === 'data-source'
+      );
+      return !dsRef || !blockedDataSourceIds.has(dsRef.id);
+    },
+    [blockedDataSourceIds]
+  );
+
+  return { filter, loading };
+};


### PR DESCRIPTION


### Description
AnalyticEngine data sources do not support DSL queries. Filter out index patterns backed by AnalyticEngine data sources in the documents and cluster layer configuration dropdowns.
### Issues Resolved
changes needed for analytic engine type compatibility

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
