### PR TITLE
Sanitize custom layer attribution text

### DIFF
--- a/public/model/customLayerFunctions.ts
+++ b/public/model/customLayerFunctions.ts
@@ -2,6 +2,31 @@ import { CustomLayerSpecification, OSMLayerSpecification } from './mapLayerType'
 import { hasLayer, removeLayers } from './map/layer_operations';
 import { MaplibreRef } from './layersFunctions';
 
+/**
+ * Sanitizes attribution text by stripping all HTML tags except safe inline
+ * elements (a, b, i, em, strong, span) and removing event handler attributes.
+ */
+const sanitizeAttribution = (attribution: string | undefined): string => {
+  if (!attribution) return '';
+  // Strip all tags except basic safe inline elements
+  const allowedTags = /<\/?(a|b|i|em|strong|span)(\s[^>]*)?>/gi;
+  const allTags = /<\/?[^>]+(>|$)/g;
+  // First, remove event handlers from allowed tags
+  const cleaned = attribution.replace(/\s+on\w+\s*=\s*(['"])[^'"]*\1/gi, '');
+  // Remove all tags that aren't in allowlist
+  const parts: string[] = [];
+  let lastIndex = 0;
+  let match;
+  const tempCleaned = cleaned;
+  // Replace allowed tags with placeholders, strip the rest
+  const result = tempCleaned.replace(allTags, (tag) => {
+    return allowedTags.test(tag) ? tag.replace(/\s+on\w+\s*=\s*[^\s>]*/gi, '') : '';
+  });
+  // Reset regex lastIndex
+  allowedTags.lastIndex = 0;
+  return result;
+};
+
 const refreshLayer = (layerConfig: CustomLayerSpecification, maplibreRef: MaplibreRef) => {
   const maplibreInstance = maplibreRef.current;
   if (maplibreInstance) {
@@ -20,7 +45,7 @@ const addNewLayer = (layerConfig: CustomLayerSpecification, maplibreRef: Maplibr
       type: 'raster',
       tiles: [tilesURL],
       tileSize: 256,
-      attribution: layerSource?.attribution,
+      attribution: sanitizeAttribution(layerSource?.attribution),
     });
     // Convert zoomRange to number[] to avoid type error for backport versions
     const zoomRange: number[] = applyZoomRangeToLayer(layerConfig);


### PR DESCRIPTION
## Description

Sanitizes user-provided attribution strings for custom map layers before passing to MapLibre. Strips disallowed HTML tags and event handler attributes, preserving only safe inline elements (a, b, i, em, strong, span).

### Changes
- Add `sanitizeAttribution` helper in `customLayerFunctions.ts`
- Apply sanitization before passing attribution to MapLibre source config

### Testing
- Custom layers with plain-text attribution display correctly
- Custom layers with link-based attribution (`<a href="...">Source</a>`) render correctly
- HTML tags outside the allowlist are stripped

---
Check the box below:
- [x] I confirm this change does not require a changelog entry