### PR TITLE
Rename ubuntu unit test to pass CI check

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -20,7 +20,7 @@ jobs:
 
   tests-linux:
     needs: Get-CI-Image-Tag
-    name: Run unit tests
+    name: Run unit tests (ubuntu-latest)
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution


### PR DESCRIPTION
### Description
Rename ubuntu unit test to pass CI check

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
