### PR TITLE
Remove hardcoded OPENSEARCH_VERSION, redundant setup-java, and update…

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -2,7 +2,6 @@ name: 'Install Dashboards with Plugin via Binary'
 
 on: [push, pull_request]
 env:
-  OPENSEARCH_VERSION: '3.1.0'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
@@ -18,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set env
         run: |
@@ -28,12 +27,6 @@ jobs:
           echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
-        with:
-          distribution: 'corretto'
-          java-version: '21'
-          
       - name: Run Opensearch
         uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@3d9a524bbfc8128d96113cc578b462153f2ea8d4
         with:


### PR DESCRIPTION
### Description
Remove hardcoded OPENSEARCH_VERSION, redundant setup-java, and update checkout to v6

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
