### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 - Adopt ESLint 10 / flat config ([#847](https://github.com/opensearch-project/dashboards-maps/pull/847))
 - Resolve transitive proprietary mapbox-gl dependency to maplibre-gl ([#849](https://github.com/opensearch-project/dashboards-maps/pull/849))
+- Migrate Jest test suite to Jest 30 + jsdom 26 ([#852](https://github.com/opensearch-project/dashboards-maps/pull/852))
 
 ### Refactoring

--- a/public/components/__snapshots__/show_error_modal.test.tsx.snap
+++ b/public/components/__snapshots__/show_error_modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`display error modal renders the error modal based on the props passed 1`] = `
 <div

--- a/public/components/__snapshots__/vector_upload_options.test.tsx.snap
+++ b/public/components/__snapshots__/vector_upload_options.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`vector_upload_options renders the VectorUploadOptions based on props provided 1`] = `
 Object {

--- a/public/components/filter_bar/__snapshots__/filter_bar.test.tsx.snap
+++ b/public/components/filter_bar/__snapshots__/filter_bar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders one filter inside filter bar 1`] = `
 <EuiFlexGroup

--- a/public/components/filter_bar/__snapshots__/filter_editor.test.tsx.snap
+++ b/public/components/filter_bar/__snapshots__/filter_editor.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders one filter inside filter bar 1`] = `
 <div>

--- a/public/components/filter_bar/__snapshots__/filter_view.test.tsx.snap
+++ b/public/components/filter_bar/__snapshots__/filter_view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`test filter display renders filter display on disabled 1`] = `
 <EuiBadge

--- a/public/components/layer_control_panel/hide_layer_button.test.tsx
+++ b/public/components/layer_control_panel/hide_layer_button.test.tsx
@@ -80,6 +80,6 @@ describe('HideLayerButton', () => {
 
     expect(button.props.title).toBe('Show layer');
     expect(button.props.iconType).toBe('eye');
-    expect(updateLayerVisibility).toBeCalledTimes(1);
+    expect(updateLayerVisibility).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/components/toolbar/spatial_filter/__snapshots__/filter-by_shape.test.tsx.snap
+++ b/public/components/toolbar/spatial_filter/__snapshots__/filter-by_shape.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`render polygon renders filter by polygon in middle of drawing 1`] = `
 <div

--- a/public/components/toolbar/spatial_filter/__snapshots__/filter_toolbar.test.tsx.snap
+++ b/public/components/toolbar/spatial_filter/__snapshots__/filter_toolbar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SpatialFilterToolbar tests renders spatial filter before drawing 1`] = `
 <EuiFlexGroup

--- a/public/components/toolbar/spatial_filter/display_draw_helper.test.tsx
+++ b/public/components/toolbar/spatial_filter/display_draw_helper.test.tsx
@@ -122,7 +122,7 @@ describe('test draw filter helper displays valid content', function () {
     });
     const button = helper.root.findByType(EuiButton);
     button.props.onClick();
-    expect(mockCallback).toBeCalledTimes(1);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
     
     await act(async () => {
       helper.unmount();

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
     '<rootDir>/test/setupTests.js',
     '<rootDir>/test/enzyme.js',
   ],
-  setupFilesAfterEnv: ['<rootDir>/test/setup.jest.js'],
+  setupFilesAfterEnv: ['jest-location-mock', '<rootDir>/test/setup.jest.js'],
   modulePaths: ['node_modules', `../../node_modules`],
   coverageDirectory: './coverage',
   moduleNameMapper: {
@@ -18,6 +18,15 @@ module.exports = {
       '<rootDir>/test/mocks/styleMock.js',
     '\\.(css|less|scss)$': '<rootDir>/test/mocks/styleMock.js',
     '^ui/(.*)': '<rootDir>/../../src/legacy/ui/public/$1/',
+    // query-string v9 is pure ESM; this shim restores the default-import shape
+    // (`import qs from 'query-string'`) under Jest's CJS transform.
+    '^query-string$': '<rootDir>/test/mocks/queryStringMock.js',
+    // Jest 30 honors the package `exports` field, so '@mapbox/mapbox-gl-draw'
+    // now resolves to its pure-ESM './index.js' instead of its legacy CJS
+    // `main` (dist/mapbox-gl-draw.js). Point it back at the prebuilt UMD dist
+    // bundle, which is CJS-compatible and loads without ESM transformation.
+    '^@mapbox/mapbox-gl-draw$':
+      '<rootDir>/node_modules/@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.js',
   },
   snapshotSerializers: ['../../node_modules/enzyme-to-json/serializer'],
   coverageReporters: ['lcov', 'text', 'cobertura'],
@@ -26,5 +35,20 @@ module.exports = {
   clearMocks: true,
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
   modulePathIgnorePatterns: [],
+  // query-string v9 and its ESM-only deps must be babel-transformed so the
+  // queryStringMock's require of the real package does not re-throw the ESM
+  // "Cannot use import statement outside a module" SyntaxError.
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules(?![/\\\\](query-string|decode-uri-component|filter-obj|split-on-first))[/\\\\].+\\.js$',
+  ],
   testEnvironment: 'jest-environment-jsdom',
+  testEnvironmentOptions: {
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -46,7 +46,7 @@ module.exports = {
     url: 'http://localhost:5601',
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/mocks/queryStringMock.js
+++ b/test/mocks/queryStringMock.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * query-string v9 is a pure ESM module whose index.js has only a default export:
+ *
+ *   import * as queryString from './base.js';
+ *   export default queryString;
+ *
+ * When Babel transforms this for CJS Jest, babel-plugin-add-module-exports sets
+ * `module.exports = exports.default` (the namespace from base.js). That namespace
+ * carries `__esModule: true` (set by base.js's own transform) but has no `.default`
+ * property. A consumer compiled as `interopRequireDefault(require('query-string')).default`
+ * then gets `undefined`.
+ *
+ * This shim is set as the moduleNameMapper target for 'query-string'.
+ * It loads the real package via an absolute path (built from __dirname) so that
+ * Jest's moduleNameMapper does not intercept the require (which would recurse
+ * into this file). The real package lives in the parent repo's node_modules.
+ */
+
+// eslint-disable-next-line import/no-dynamic-require
+const mod = require(require('path').resolve(
+  __dirname,
+  '../../../../node_modules/query-string/index.js'
+));
+
+// After the Babel + babel-plugin-add-module-exports pipeline, `mod` is the raw
+// namespace object `{ __esModule: true, stringify, parse, ... }` with no `.default`.
+// Recover the actual API regardless of which shape we receive.
+const api = mod && mod.__esModule && typeof mod.stringify !== 'function' ? mod.default : mod;
+
+module.exports = {
+  __esModule: true,
+  default: api,
+};

--- a/test/setup.jest.js
+++ b/test/setup.jest.js
@@ -35,3 +35,21 @@ afterEach(() => {
   console.error.mockRestore();
 });
 window.URL.createObjectURL = function () {};
+
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'.
+process.env.HOST = 'http://localhost:5601';
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+['localStorage', 'sessionStorage'].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
+});


### PR DESCRIPTION
Closes #851

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `25 suites / 119 tests / 12 snapshots passed`, exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }`; added the
  `snapshotFormat: { escapeString: true, printBasicPrototype: true }` compatibility shim (Jest 29
  flipped these defaults, which would otherwise invalidate existing snapshots).
- **Setup (`test/setup.jest.js`):** set `process.env.HOST = 'http://localhost:5601'` so
  jest-location-mock's `window.location` base URL matches `testEnvironmentOptions.url`; re-declared
  the now-non-configurable `localStorage`/`sessionStorage` as configurable (jsdom 26) so individual
  tests can still override them via `Object.defineProperty`.
- **Matcher codemod:** `toBeCalledTimes` → `toHaveBeenCalledTimes` (Jest 30 removed the aliases) in
  `public/components/layer_control_panel/hide_layer_button.test.tsx` and
  `public/components/toolbar/spatial_filter/display_draw_helper.test.tsx`.
- **Snapshots:** bumped the snapshot header URL (`goo.gl/fbAQLP` →
  `jestjs.io/docs/snapshot-testing`) across 7 `.snap` files — Jest 30 refuses to load the old
  header. No snapshot content was regenerated; verified every diff is the header line only, with no
  serialization or content changes.

#### Plugin-specific changes
- **`query-string` v9 pure-ESM fix (`test/jest.config.js` + new `test/mocks/queryStringMock.js`):**
  query-string v9 ships only a default export from an ESM `index.js`. Under Jest's CJS transform +
  `babel-plugin-add-module-exports`, a consumer's `interopRequireDefault(require('query-string')).default`
  resolves to `undefined`. Added a `moduleNameMapper` entry pointing `^query-string$` at
  `test/mocks/queryStringMock.js`, a shim that loads the real package via an absolute
  (moduleNameMapper-proof) path and re-exposes a correct `{ __esModule: true, default }` shape.
  Also added a `transformIgnorePatterns` allowlist so `query-string` and its ESM-only deps
  (`decode-uri-component`, `filter-obj`, `split-on-first`) are babel-transformed rather than
  re-throwing "Cannot use import statement outside a module".
- **`@mapbox/mapbox-gl-draw` ESM `exports` fix (`test/jest.config.js`):** Jest 30 now honors the
  package `exports` field, so `@mapbox/mapbox-gl-draw` resolves to its pure-ESM `./index.js` instead
  of the legacy CJS `main`. Added a `moduleNameMapper` entry pointing `^@mapbox/mapbox-gl-draw$` at
  the prebuilt UMD `dist/mapbox-gl-draw.js`, which is CJS-compatible and loads without ESM
  transformation.

No `package.json` change needed for the Jest 30 migration — the plugin inherits the parent repo's
Jest 30 stack, and `TextEncoder`/`TextDecoder` are already polyfilled in `test/polyfills.js`.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<this-plugin-issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
