### PR TITLE
feat: Add custom icon support for document layer markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.x](https://github.com/opensearch-project/dashboards-maps/compare/main...HEAD)
 
 ### Features
+* feat: Add custom icon support for document layer markers ([#859](https://github.com/opensearch-project/dashboards-maps/pull/859))
 
 ### Enhancements
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {},
   "resolutions": {
-    "@types/mapbox__mapbox-gl-draw/mapbox-gl": "npm:maplibre-gl@5.2.0"
+    "@types/mapbox__mapbox-gl-draw/mapbox-gl": "npm:maplibre-gl@5.2.0",
+    "nanoid": "^5.1.16"
   }
 }

--- a/public/components/layer_config/documents_config/style/custom_icon_upload.tsx
+++ b/public/components/layer_config/documents_config/style/custom_icon_upload.tsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useCallback, useRef } from 'react';
+import {
+  EuiButton,
+  EuiCompressedFieldText,
+  EuiCompressedFormRow,
+  EuiFilePicker,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiSpacer,
+  EuiTitle,
+  EuiText,
+  EuiCallOut,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { CoreStart } from '../../../../../../src/core/public';
+
+interface CustomIconUploadProps {
+  http: CoreStart['http'];
+  notifications: CoreStart['notifications'];
+  onUploadSuccess: (iconId: string, iconName: string, svg: string) => void;
+  onClose: () => void;
+}
+
+const MAX_SVG_SIZE = 100 * 1024; // 100KB
+
+const validateSvg = (content: string): { valid: boolean; error?: string } => {
+  if (!content.includes('<svg')) {
+    return {
+      valid: false,
+      error: i18n.translate('maps.icons.upload.invalidSvg', {
+        defaultMessage: 'File does not appear to be a valid SVG',
+      }),
+    };
+  }
+  return { valid: true };
+};
+
+export const CustomIconUpload = ({
+  http,
+  notifications,
+  onUploadSuccess,
+  onClose,
+}: CustomIconUploadProps) => {
+  const [iconName, setIconName] = useState('');
+  const [svgContent, setSvgContent] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const filePickerRef = useRef<EuiFilePicker>(null);
+
+  const onFileChange = useCallback((files: FileList | null) => {
+    if (!files || files.length === 0) {
+      setSvgContent(null);
+      setFileName(null);
+      setValidationError(null);
+      return;
+    }
+
+    const file = files[0];
+    setFileName(file.name);
+
+    if (!file.name.endsWith('.svg')) {
+      setValidationError(
+        i18n.translate('maps.icons.upload.svgOnly', {
+          defaultMessage: 'Only SVG files are supported',
+        })
+      );
+      setSvgContent(null);
+      return;
+    }
+
+    // Check byte size from File object before reading into memory
+    if (file.size > MAX_SVG_SIZE) {
+      setValidationError(
+        i18n.translate('maps.icons.upload.tooLarge', {
+          defaultMessage: 'SVG file must be less than 100KB',
+        })
+      );
+      setSvgContent(null);
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      const validation = validateSvg(content);
+      if (!validation.valid) {
+        setValidationError(validation.error!);
+        setSvgContent(null);
+      } else {
+        setValidationError(null);
+        setSvgContent(content);
+        // Auto-fill name from filename if not set
+        if (!iconName) {
+          const nameFromFile = file.name.replace(/\.svg$/i, '').replace(/[-_]/g, ' ');
+          setIconName(nameFromFile);
+        }
+      }
+    };
+    reader.readAsText(file);
+  }, [iconName]);
+
+  const onUpload = useCallback(async () => {
+    if (!svgContent || !iconName.trim()) {
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      const result = await http.post('/api/maps-dashboards/icons', {
+        body: JSON.stringify({
+          name: iconName.trim(),
+          svg: svgContent,
+        }),
+      });
+
+      notifications.toasts.addSuccess(
+        i18n.translate('maps.icons.upload.success', {
+          defaultMessage: 'Icon "{name}" uploaded successfully',
+          values: { name: iconName },
+        })
+      );
+
+      onUploadSuccess((result as any).id, iconName.trim(), svgContent);
+      onClose();
+    } catch (error: any) {
+      notifications.toasts.addDanger(
+        i18n.translate('maps.icons.upload.error', {
+          defaultMessage: 'Failed to upload icon: {message}',
+          values: { message: error.body?.message || error.message || 'Unknown error' },
+        })
+      );
+    } finally {
+      setIsUploading(false);
+    }
+  }, [svgContent, iconName, http, notifications, onUploadSuccess, onClose]);
+
+  const isUploadDisabled = !svgContent || !iconName.trim() || !!validationError || isUploading;
+
+  return (
+    <EuiFlyout onClose={onClose} size="s" aria-labelledby="customIconUploadTitle">
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id="customIconUploadTitle">
+            {i18n.translate('maps.icons.upload.title', {
+              defaultMessage: 'Upload custom icon',
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiText size="s" color="subdued">
+          {i18n.translate('maps.icons.upload.description', {
+            defaultMessage:
+              'Upload an SVG file to use as a custom map icon. The icon will be available across all maps.',
+          })}
+        </EuiText>
+        <EuiSpacer size="m" />
+        {validationError && (
+          <>
+            <EuiCallOut
+              title={validationError}
+              color="danger"
+              iconType="alert"
+              size="s"
+            />
+            <EuiSpacer size="m" />
+          </>
+        )}
+        <EuiCompressedFormRow
+          label={i18n.translate('maps.icons.upload.nameLabel', {
+            defaultMessage: 'Icon name',
+          })}
+          fullWidth={true}
+        >
+          <EuiCompressedFieldText
+            value={iconName}
+            onChange={(e) => setIconName(e.target.value)}
+            placeholder={i18n.translate('maps.icons.upload.namePlaceholder', {
+              defaultMessage: 'Enter a name for this icon',
+            })}
+            fullWidth={true}
+          />
+        </EuiCompressedFormRow>
+        <EuiSpacer size="m" />
+        <EuiCompressedFormRow
+          label={i18n.translate('maps.icons.upload.fileLabel', {
+            defaultMessage: 'SVG file',
+          })}
+          fullWidth={true}
+        >
+          <EuiFilePicker
+            ref={filePickerRef}
+            accept=".svg"
+            onChange={onFileChange}
+            display="default"
+            fullWidth={true}
+            initialPromptText={i18n.translate('maps.icons.upload.filePrompt', {
+              defaultMessage: 'Select or drag and drop an SVG file',
+            })}
+          />
+        </EuiCompressedFormRow>
+        {svgContent && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCompressedFormRow
+              label={i18n.translate('maps.icons.upload.previewLabel', {
+                defaultMessage: 'Preview',
+              })}
+              fullWidth={true}
+            >
+              <EuiFlexGroup justifyContent="center" alignItems="center">
+                <EuiFlexItem grow={false}>
+                  <img
+                    src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`}
+                    width={48}
+                    height={48}
+                    alt="Icon preview"
+                    style={{
+                      border: '1px solid #D3DAE6',
+                      borderRadius: 4,
+                      padding: 8,
+                    }}
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiCompressedFormRow>
+          </>
+        )}
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={onClose} color="text">
+              {i18n.translate('maps.icons.upload.cancel', { defaultMessage: 'Cancel' })}
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              onClick={onUpload}
+              fill
+              isDisabled={isUploadDisabled}
+              isLoading={isUploading}
+            >
+              {i18n.translate('maps.icons.upload.uploadButton', { defaultMessage: 'Upload' })}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </EuiFlyout>
+  );
+};

--- a/public/components/layer_config/documents_config/style/document_layer_style.tsx
+++ b/public/components/layer_config/documents_config/style/document_layer_style.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../../../common';
 import { LabelConfig } from './label_config';
 import { ColorPicker } from './color_picker';
+import { IconConfig } from './icon_config';
 import { IndexPattern } from '../../../../../../../src/plugins/data/common';
 
 interface Props {
@@ -44,6 +45,12 @@ export const DocumentLayerStyle = ({
   const geoTypeToggleButtonGroupPrefix = 'geoTypeToggleButtonGroup';
   const [toggleGeoTypeIdSelected, setToggleGeoTypeIdSelected] = useState(
     `${geoTypeToggleButtonGroupPrefix}__Point`
+  );
+
+  const markerTypeTogglePrefix = 'markerTypeToggle';
+  const currentMarkerType = selectedLayerConfig?.style?.markerType || 'marker';
+  const [toggleMarkerTypeIdSelected, setToggleMarkerTypeIdSelected] = useState(
+    `${markerTypeTogglePrefix}__${currentMarkerType === 'icon' ? 'Icon' : 'Marker'}`
   );
 
   useEffect(() => {
@@ -103,6 +110,38 @@ export const DocumentLayerStyle = ({
 
   const onChangeGeoTypeSelected = (optionId: string) => {
     setToggleGeoTypeIdSelected(optionId);
+  };
+
+  const toggleButtonsMarkerType = [
+    {
+      id: `${markerTypeTogglePrefix}__Marker`,
+      label: i18n.translate('maps.documents.markerType', { defaultMessage: 'Marker' }),
+    },
+    {
+      id: `${markerTypeTogglePrefix}__Icon`,
+      label: i18n.translate('maps.documents.iconType', { defaultMessage: 'Icon' }),
+    },
+  ];
+
+  const onChangeMarkerTypeSelected = (optionId: string) => {
+    setToggleMarkerTypeIdSelected(optionId);
+    const newMarkerType = optionId === `${markerTypeTogglePrefix}__Icon` ? 'icon' : 'marker';
+    setSelectedLayerConfig({
+      ...selectedLayerConfig,
+      style: {
+        ...selectedLayerConfig?.style,
+        markerType: newMarkerType,
+        // Initialize iconConfig with defaults when switching to icon mode
+        ...(newMarkerType === 'icon' && !selectedLayerConfig?.style?.iconConfig
+          ? {
+              iconConfig: {
+                iconId: 'pin',
+                iconSize: 24,
+              },
+            }
+          : {}),
+      },
+    });
   };
 
   interface WidthSelectorProps {
@@ -187,44 +226,65 @@ export const DocumentLayerStyle = ({
           <EuiForm>
             {toggleGeoTypeIdSelected === `${geoTypeToggleButtonGroupPrefix}__Point` && (
               <EuiForm>
-                <ColorPicker
-                  originColor={selectedLayerConfig?.style?.fillColor}
-                  label={i18n.translate('maps.documents.symbolFillColor', {
-                    defaultMessage: 'Fill color',
-                  })}
-                  selectedLayerConfigId={selectedLayerConfig.id}
-                  setIsUpdateDisabled={setIsUpdateDisabled}
-                  onColorChange={onFillColorChange}
+                <EuiButtonGroup
+                  name="MarkerTypeToggleButtonGroup"
+                  legend="Toggle between marker and icon style"
+                  options={toggleButtonsMarkerType}
+                  idSelected={toggleMarkerTypeIdSelected}
+                  onChange={(id) => onChangeMarkerTypeSelected(id)}
+                  buttonSize="compressed"
                 />
-                <ColorPicker
-                  originColor={selectedLayerConfig?.style?.borderColor}
-                  label={i18n.translate('maps.documents.symbolBorderColor', {
-                    defaultMessage: 'Border color',
-                  })}
-                  selectedLayerConfigId={selectedLayerConfig.id}
-                  setIsUpdateDisabled={setIsUpdateDisabled}
-                  onColorChange={onBorderColorChange}
-                />
-                <WidthSelector
-                  label={i18n.translate('maps.documents.symbolBorderThickness', {
-                    defaultMessage: 'Border thickness',
-                  })}
-                  size={selectedLayerConfig?.style?.borderThickness}
-                  onWidthChange={onBorderThicknessChange}
-                  hasInvalid={hasInvalidThickness}
-                  min={DOCUMENTS_MIN_MARKER_BORDER_THICKNESS}
-                  max={DOCUMENTS_MAX_MARKER_BORDER_THICKNESS}
-                />
-                <WidthSelector
-                  label={i18n.translate('maps.documents.symbolMarkerSize', {
-                    defaultMessage: 'Marker size',
-                  })}
-                  size={selectedLayerConfig?.style?.markerSize}
-                  onWidthChange={onMarkerSizeChange}
-                  hasInvalid={hasInvalidSize}
-                  min={DOCUMENTS_MIN_MARKER_SIZE}
-                  max={DOCUMENTS_MAX_MARKER_SIZE}
-                />
+                <EuiSpacer size="s" />
+                {toggleMarkerTypeIdSelected === `${markerTypeTogglePrefix}__Marker` && (
+                  <>
+                    <ColorPicker
+                      originColor={selectedLayerConfig?.style?.fillColor}
+                      label={i18n.translate('maps.documents.symbolFillColor', {
+                        defaultMessage: 'Fill color',
+                      })}
+                      selectedLayerConfigId={selectedLayerConfig.id}
+                      setIsUpdateDisabled={setIsUpdateDisabled}
+                      onColorChange={onFillColorChange}
+                    />
+                    <ColorPicker
+                      originColor={selectedLayerConfig?.style?.borderColor}
+                      label={i18n.translate('maps.documents.symbolBorderColor', {
+                        defaultMessage: 'Border color',
+                      })}
+                      selectedLayerConfigId={selectedLayerConfig.id}
+                      setIsUpdateDisabled={setIsUpdateDisabled}
+                      onColorChange={onBorderColorChange}
+                    />
+                    <WidthSelector
+                      label={i18n.translate('maps.documents.symbolBorderThickness', {
+                        defaultMessage: 'Border thickness',
+                      })}
+                      size={selectedLayerConfig?.style?.borderThickness}
+                      onWidthChange={onBorderThicknessChange}
+                      hasInvalid={hasInvalidThickness}
+                      min={DOCUMENTS_MIN_MARKER_BORDER_THICKNESS}
+                      max={DOCUMENTS_MAX_MARKER_BORDER_THICKNESS}
+                    />
+                    <WidthSelector
+                      label={i18n.translate('maps.documents.symbolMarkerSize', {
+                        defaultMessage: 'Marker size',
+                      })}
+                      size={selectedLayerConfig?.style?.markerSize}
+                      onWidthChange={onMarkerSizeChange}
+                      hasInvalid={hasInvalidSize}
+                      min={DOCUMENTS_MIN_MARKER_SIZE}
+                      max={DOCUMENTS_MAX_MARKER_SIZE}
+                    />
+                  </>
+                )}
+                {toggleMarkerTypeIdSelected === `${markerTypeTogglePrefix}__Icon` && (
+                  <IconConfig
+                    selectedLayerConfig={selectedLayerConfig}
+                    setSelectedLayerConfig={setSelectedLayerConfig}
+                    setIsUpdateDisabled={setIsUpdateDisabled}
+                    indexPattern={indexPattern}
+                  />
+                )}
               </EuiForm>
             )}
             {toggleGeoTypeIdSelected === `${geoTypeToggleButtonGroupPrefix}__Line` && (

--- a/public/components/layer_config/documents_config/style/icon_config.tsx
+++ b/public/components/layer_config/documents_config/style/icon_config.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  EuiCompressedFormRow,
+  EuiSpacer,
+  EuiCompressedFieldNumber,
+  EuiFormLabel,
+  EuiButtonGroup,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { DocumentLayerSpecification } from '../../../../model/mapLayerType';
+import { IndexPattern } from '../../../../../../../src/plugins/data/common';
+import { IconPicker } from './icon_picker';
+import { ColorPicker } from './color_picker';
+import {
+  DEFAULT_ICON_ID,
+  DEFAULT_ICON_FILL_COLOR,
+  DEFAULT_ICON_STROKE_COLOR,
+  getBuiltInIconById,
+} from '../../../map_icons';
+
+interface IconConfigProps {
+  selectedLayerConfig: DocumentLayerSpecification;
+  setSelectedLayerConfig: Function;
+  setIsUpdateDisabled: Function;
+  indexPattern: IndexPattern | null | undefined;
+}
+
+const DEFAULT_ICON_SIZE = 24;
+const MIN_ICON_SIZE = 8;
+const MAX_ICON_SIZE = 64;
+
+const styleTogglePrefix = 'iconStyleToggle';
+
+export const IconConfig = ({
+  selectedLayerConfig,
+  setSelectedLayerConfig,
+  setIsUpdateDisabled,
+  indexPattern,
+}: IconConfigProps) => {
+  const iconConfig = selectedLayerConfig?.style?.iconConfig;
+  const iconId = iconConfig?.iconId || DEFAULT_ICON_ID;
+  const iconSize = iconConfig?.iconSize || DEFAULT_ICON_SIZE;
+  const iconStyle = iconConfig?.iconStyle || 'filled';
+  const fillColor = iconConfig?.fillColor || DEFAULT_ICON_FILL_COLOR;
+  const strokeColor = iconConfig?.strokeColor || DEFAULT_ICON_STROKE_COLOR;
+
+  const [hasInvalidSize, setHasInvalidSize] = useState(false);
+  const [toggleStyleIdSelected, setToggleStyleIdSelected] = useState(
+    `${styleTogglePrefix}__${iconStyle === 'outline' ? 'Outline' : 'Filled'}`
+  );
+
+  useEffect(() => {
+    setHasInvalidSize(iconSize < MIN_ICON_SIZE || iconSize > MAX_ICON_SIZE);
+  }, [iconSize]);
+
+  useEffect(() => {
+    setIsUpdateDisabled(hasInvalidSize);
+  }, [hasInvalidSize]);
+
+  const updateIconConfig = useCallback(
+    (updates: Partial<DocumentLayerSpecification['style']['iconConfig']>) => {
+      setSelectedLayerConfig({
+        ...selectedLayerConfig,
+        style: {
+          ...selectedLayerConfig?.style,
+          iconConfig: {
+            ...selectedLayerConfig?.style?.iconConfig,
+            iconId,
+            ...updates,
+          },
+        },
+      });
+    },
+    [selectedLayerConfig, setSelectedLayerConfig, iconId]
+  );
+
+  const onIconSelect = (selectedIconId: string, svg?: string) => {
+    const builtInIcon = getBuiltInIconById(selectedIconId);
+    if (builtInIcon) {
+      updateIconConfig({ iconId: selectedIconId, svg: undefined });
+    } else {
+      updateIconConfig({ iconId: selectedIconId, svg });
+    }
+  };
+
+  const onIconSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateIconConfig({ iconSize: Number(e.target.value) });
+  };
+
+  const onStyleChange = (optionId: string) => {
+    setToggleStyleIdSelected(optionId);
+    const newStyle = optionId === `${styleTogglePrefix}__Outline` ? 'outline' : 'filled';
+    updateIconConfig({ iconStyle: newStyle });
+  };
+
+  const onFillColorChange = (color: string) => {
+    updateIconConfig({ fillColor: color });
+  };
+
+  const onStrokeColorChange = (color: string) => {
+    updateIconConfig({ strokeColor: color });
+  };
+
+  const styleToggleButtons = [
+    {
+      id: `${styleTogglePrefix}__Filled`,
+      label: i18n.translate('maps.documents.iconStyleFilled', { defaultMessage: 'Filled' }),
+    },
+    {
+      id: `${styleTogglePrefix}__Outline`,
+      label: i18n.translate('maps.documents.iconStyleOutline', { defaultMessage: 'Outline' }),
+    },
+  ];
+
+  // Determine if selected icon is a built-in (show color controls) or custom
+  const isBuiltIn = !!getBuiltInIconById(iconId);
+
+  return (
+    <>
+      <EuiCompressedFormRow
+        label={i18n.translate('maps.documents.selectIcon', {
+          defaultMessage: 'Icon',
+        })}
+        fullWidth={true}
+      >
+        <IconPicker selectedIconId={iconId} onIconSelect={onIconSelect} />
+      </EuiCompressedFormRow>
+      <EuiSpacer size="s" />
+      {isBuiltIn && (
+        <>
+          <EuiCompressedFormRow
+            label={i18n.translate('maps.documents.iconStyle', {
+              defaultMessage: 'Style',
+            })}
+            fullWidth={true}
+          >
+            <EuiButtonGroup
+              name="iconStyleButtonGroup"
+              legend="Icon style"
+              options={styleToggleButtons}
+              idSelected={toggleStyleIdSelected}
+              onChange={onStyleChange}
+              buttonSize="compressed"
+            />
+          </EuiCompressedFormRow>
+          <EuiSpacer size="s" />
+          {iconStyle === 'filled' && (
+            <ColorPicker
+              originColor={fillColor}
+              label={i18n.translate('maps.documents.iconFillColor', {
+                defaultMessage: 'Fill color',
+              })}
+              selectedLayerConfigId={selectedLayerConfig.id}
+              setIsUpdateDisabled={setIsUpdateDisabled}
+              onColorChange={onFillColorChange}
+            />
+          )}
+          <ColorPicker
+            originColor={strokeColor}
+            label={i18n.translate('maps.documents.iconStrokeColor', {
+              defaultMessage: 'Outline color',
+            })}
+            selectedLayerConfigId={selectedLayerConfig.id}
+            setIsUpdateDisabled={setIsUpdateDisabled}
+            onColorChange={onStrokeColorChange}
+          />
+          <EuiSpacer size="s" />
+        </>
+      )}
+      <EuiCompressedFormRow
+        label={i18n.translate('maps.documents.iconSize', {
+          defaultMessage: 'Icon size',
+        })}
+        fullWidth={true}
+        isInvalid={hasInvalidSize}
+        error={i18n.translate('maps.documents.style.invalidIconSize', {
+          defaultMessage: 'Must be between {min} and {max}',
+          values: { min: MIN_ICON_SIZE, max: MAX_ICON_SIZE },
+        })}
+      >
+        <EuiCompressedFieldNumber
+          value={iconSize}
+          onChange={onIconSizeChange}
+          isInvalid={hasInvalidSize}
+          append={<EuiFormLabel>px</EuiFormLabel>}
+          fullWidth={true}
+          min={MIN_ICON_SIZE}
+          max={MAX_ICON_SIZE}
+        />
+      </EuiCompressedFormRow>
+    </>
+  );
+};

--- a/public/components/layer_config/documents_config/style/icon_picker.tsx
+++ b/public/components/layer_config/documents_config/style/icon_picker.tsx
@@ -1,0 +1,310 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiButtonEmpty,
+  EuiTabs,
+  EuiTab,
+  EuiSpacer,
+  EuiToolTip,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import {
+  ALL_BUILT_IN_ICONS,
+  getBuiltInIconById,
+  DEFAULT_ICON_ID,
+  DEFAULT_ICON_FILL_COLOR,
+  DEFAULT_ICON_STROKE_COLOR,
+  applyIconColors,
+} from '../../../map_icons';
+import { useOpenSearchDashboards } from '../../../../../../../src/plugins/opensearch_dashboards_react/public';
+import { CustomIconUpload } from './custom_icon_upload';
+
+interface IconPickerProps {
+  selectedIconId: string;
+  onIconSelect: (iconId: string, svg?: string) => void;
+}
+
+interface CustomIcon {
+  id: string;
+  name: string;
+  svg: string;
+}
+
+interface CustomIconMetadata {
+  id: string;
+  name: string;
+}
+
+const ICON_BUTTON_SIZE = 32;
+
+const IconPreview = ({ svg, size = 20 }: { svg: string; size?: number }) => {
+  const dataUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  return (
+    <img
+      src={dataUrl}
+      width={size}
+      height={size}
+      alt=""
+      style={{ display: 'inline-block' }}
+    />
+  );
+};
+
+export const IconPicker = ({ selectedIconId, onIconSelect }: IconPickerProps) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [selectedTab, setSelectedTab] = useState<'builtin' | 'custom'>('builtin');
+  const [customIcons, setCustomIcons] = useState<CustomIcon[]>([]);
+  const [showUploadFlyout, setShowUploadFlyout] = useState(false);
+
+  const { services } = useOpenSearchDashboards();
+  const http = services.http!;
+  const notifications = services.notifications!;
+
+  // Load custom icons — list returns metadata only, then fetch each SVG
+  const loadCustomIcons = useCallback(async () => {
+    try {
+      const response = (await http.get('/api/maps-dashboards/icons')) as { icons: CustomIconMetadata[] };
+      const iconMetadataList = response.icons || [];
+
+      // Fetch SVG content for each icon
+      const iconsWithSvg = await Promise.all(
+        iconMetadataList.map(async (meta) => {
+          try {
+            const detail = (await http.get(`/api/maps-dashboards/icons/${meta.id}`)) as CustomIcon;
+            return { id: meta.id, name: meta.name, svg: detail.svg };
+          } catch {
+            return { id: meta.id, name: meta.name, svg: '' };
+          }
+        })
+      );
+      setCustomIcons(iconsWithSvg.filter((icon) => icon.svg));
+    } catch (e) {
+      setCustomIcons([]);
+    }
+  }, [http]);
+
+  useEffect(() => {
+    loadCustomIcons();
+  }, [loadCustomIcons]);
+
+  const deleteCustomIcon = useCallback(
+    async (iconIdToDelete: string) => {
+      try {
+        await http.delete(`/api/maps-dashboards/icons/${iconIdToDelete}`);
+        setCustomIcons((prev) => prev.filter((icon) => icon.id !== iconIdToDelete));
+        notifications.toasts.addSuccess(
+          i18n.translate('maps.documents.iconDeleted', {
+            defaultMessage: 'Icon deleted',
+          })
+        );
+      } catch (e: any) {
+        notifications.toasts.addDanger(
+          i18n.translate('maps.documents.iconDeleteFailed', {
+            defaultMessage: 'Failed to delete icon',
+          })
+        );
+      }
+    },
+    [http, notifications]
+  );
+
+  // Check if selected icon is a custom one
+  const selectedBuiltIn = getBuiltInIconById(selectedIconId);
+  const selectedCustom = customIcons.find((icon) => icon.id === selectedIconId);
+  const selectedIcon = selectedBuiltIn || selectedCustom;
+
+  const togglePopover = () => setIsPopoverOpen(!isPopoverOpen);
+  const closePopover = () => setIsPopoverOpen(false);
+
+  const handleIconClick = (iconId: string, svg: string) => {
+    onIconSelect(iconId, svg);
+    closePopover();
+  };
+
+  const handleUploadSuccess = (iconId: string, iconName: string, svg: string) => {
+    setCustomIcons((prev) => [...prev, { id: iconId, name: iconName, svg }]);
+    onIconSelect(iconId, svg);
+  };
+
+  const tabs = [
+    {
+      id: 'builtin',
+      name: i18n.translate('maps.documents.iconSetBuiltIn', { defaultMessage: 'Built-in' }),
+    },
+    {
+      id: 'custom',
+      name: i18n.translate('maps.documents.iconSetCustom', { defaultMessage: 'Custom' }),
+    },
+  ];
+
+  const getIconsForTab = () => {
+    if (selectedTab === 'custom') {
+      return customIcons.map((icon) => ({
+        id: icon.id,
+        name: icon.name,
+        svg: icon.svg,
+      }));
+    }
+    return ALL_BUILT_IN_ICONS;
+  };
+
+  const iconsToShow = getIconsForTab();
+
+  // For built-in icon preview in the picker, show with default colors
+  const getPreviewSvg = (icon: { id: string; svg: string }): string => {
+    const builtIn = getBuiltInIconById(icon.id);
+    if (builtIn) {
+      return applyIconColors(builtIn.svg, DEFAULT_ICON_FILL_COLOR, DEFAULT_ICON_STROKE_COLOR, 'filled');
+    }
+    return icon.svg;
+  };
+
+  // Preview the selected icon in the trigger button with default colors
+  const triggerPreviewSvg = selectedIcon
+    ? getBuiltInIconById(selectedIcon.id)
+      ? applyIconColors(selectedIcon.svg, DEFAULT_ICON_FILL_COLOR, DEFAULT_ICON_STROKE_COLOR, 'filled')
+      : selectedIcon.svg
+    : undefined;
+
+  const button = (
+    <EuiButtonEmpty
+      onClick={togglePopover}
+      iconType="arrowDown"
+      iconSide="right"
+      size="s"
+      style={{ width: '100%', justifyContent: 'space-between' }}
+    >
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          {triggerPreviewSvg && <IconPreview svg={triggerPreviewSvg} size={16} />}
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <span>{selectedIcon?.name || 'Select icon'}</span>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiButtonEmpty>
+  );
+
+  return (
+    <>
+      <EuiPopover
+        button={button}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+        panelPaddingSize="s"
+        anchorPosition="downLeft"
+      >
+        <div style={{ width: 280 }}>
+          <EuiTabs size="s">
+            {tabs.map((tab) => (
+              <EuiTab
+                key={tab.id}
+                isSelected={selectedTab === tab.id}
+                onClick={() => setSelectedTab(tab.id as 'builtin' | 'custom')}
+              >
+                {tab.name}
+              </EuiTab>
+            ))}
+          </EuiTabs>
+          <EuiSpacer size="s" />
+          {selectedTab === 'custom' && iconsToShow.length === 0 && (
+            <>
+              <EuiText size="s" color="subdued" textAlign="center">
+                {i18n.translate('maps.documents.noCustomIcons', {
+                  defaultMessage: 'No custom icons uploaded yet.',
+                })}
+              </EuiText>
+              <EuiSpacer size="s" />
+            </>
+          )}
+          <EuiFlexGroup wrap responsive={false} gutterSize="xs">
+            {iconsToShow.map((icon) => (
+              <EuiFlexItem key={icon.id} grow={false}>
+                <EuiToolTip
+                  content={
+                    selectedTab === 'custom'
+                      ? `${icon.name} (right-click to delete)`
+                      : icon.name
+                  }
+                  position="top"
+                >
+                  <button
+                    type="button"
+                    onClick={() => handleIconClick(icon.id, icon.svg)}
+                    onContextMenu={
+                      selectedTab === 'custom'
+                        ? (e) => {
+                            e.preventDefault();
+                            if (
+                              window.confirm(
+                                `Delete icon "${icon.name}"? Layers using it will show a placeholder.`
+                              )
+                            ) {
+                              deleteCustomIcon(icon.id);
+                            }
+                          }
+                        : undefined
+                    }
+                    aria-label={icon.name}
+                    style={{
+                      width: ICON_BUTTON_SIZE,
+                      height: ICON_BUTTON_SIZE,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      border:
+                        selectedIconId === icon.id
+                          ? '2px solid #006BB4'
+                          : '1px solid transparent',
+                      borderRadius: 4,
+                      cursor: 'pointer',
+                      background:
+                        selectedIconId === icon.id ? 'rgba(0, 107, 180, 0.1)' : 'transparent',
+                      padding: 2,
+                    }}
+                  >
+                    <IconPreview svg={getPreviewSvg(icon)} size={20} />
+                  </button>
+                </EuiToolTip>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+          {selectedTab === 'custom' && (
+            <>
+              <EuiSpacer size="s" />
+              <EuiButtonEmpty
+                size="s"
+                iconType="plusInCircle"
+                onClick={() => {
+                  closePopover();
+                  setShowUploadFlyout(true);
+                }}
+                style={{ width: '100%' }}
+              >
+                {i18n.translate('maps.documents.uploadCustomIcon', {
+                  defaultMessage: 'Upload custom icon',
+                })}
+              </EuiButtonEmpty>
+            </>
+          )}
+        </div>
+      </EuiPopover>
+      {showUploadFlyout && (
+        <CustomIconUpload
+          http={http}
+          notifications={notifications}
+          onUploadSuccess={handleUploadSuccess}
+          onClose={() => setShowUploadFlyout(false)}
+        />
+      )}
+    </>
+  );
+};

--- a/public/components/map_icons/default_icons.ts
+++ b/public/components/map_icons/default_icons.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Built-in map icons. Each icon uses `currentColor` for fill and stroke so
+ * that fill color and outline color can be applied at render time.
+ *
+ * Icons come in two style variants controlled by the caller:
+ *   filled  – shape has a solid fill
+ *   outline – shape has no fill, only a stroke outline
+ *
+ * The SVG templates use placeholder tokens:
+ *   FILL_COLOR   – replaced with the user's chosen fill color
+ *   STROKE_COLOR – replaced with the user's chosen outline color
+ */
+
+export interface MapIcon {
+  id: string;
+  name: string;
+  /** SVG template using FILL_COLOR and STROKE_COLOR tokens */
+  svg: string;
+}
+
+// ─── General ─────────────────────────────────────────────────────────────────
+
+const pin: MapIcon = {
+  id: 'pin',
+  name: 'Pin',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>`,
+};
+
+const circle: MapIcon = {
+  id: 'circle',
+  name: 'Circle',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><circle cx="12" cy="12" r="10"/></svg>`,
+};
+
+const square: MapIcon = {
+  id: 'square',
+  name: 'Square',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>`,
+};
+
+const diamond: MapIcon = {
+  id: 'diamond',
+  name: 'Diamond',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M12 2L2 12l10 10 10-10L12 2z"/></svg>`,
+};
+
+const star: MapIcon = {
+  id: 'star',
+  name: 'Star',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>`,
+};
+
+const triangle: MapIcon = {
+  id: 'triangle',
+  name: 'Triangle',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M12 3L2 21h20L12 3z"/></svg>`,
+};
+
+const home: MapIcon = {
+  id: 'home',
+  name: 'Home',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>`,
+};
+
+// ─── Transportation ───────────────────────────────────────────────────────────
+
+const airport: MapIcon = {
+  id: 'airport',
+  name: 'Airport',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M21 16v-2l-8-5V3.5c0-.83-.67-1.5-1.5-1.5S10 2.67 10 3.5V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z"/></svg>`,
+};
+
+const ship: MapIcon = {
+  id: 'ship',
+  name: 'Ship',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M20 21c-1.39 0-2.78-.47-4-1.32-2.44 1.71-5.56 1.71-8 0C6.78 20.53 5.39 21 4 21H2v2h2c1.38 0 2.74-.35 4-.99 2.52 1.29 5.48 1.29 8 0 1.26.65 2.62.99 4 .99h2v-2h-2zM3.95 19H4c1.6 0 3.02-.88 4-2 .98 1.12 2.4 2 4 2s3.02-.88 4-2c.98 1.12 2.4 2 4 2h.05l1.89-6.68c.08-.26.06-.54-.06-.78s-.34-.42-.6-.5L20 10.62V6c0-1.1-.9-2-2-2h-3V1H9v3H6c-1.1 0-2 .9-2 2v4.62l-1.29.42c-.26.08-.48.26-.6.5s-.14.52-.06.78L3.95 19zM6 6h12v3.97L12 8 6 9.97V6z"/></svg>`,
+};
+
+const truck: MapIcon = {
+  id: 'truck',
+  name: 'Truck',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm13.5-9l1.96 2.5H17V9.5h2.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>`,
+};
+
+// ─── Services ─────────────────────────────────────────────────────────────────
+
+const hospital: MapIcon = {
+  id: 'hospital',
+  name: 'Hospital',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-1 11h-4v4h-4v-4H6v-4h4V6h4v4h4v4z"/></svg>`,
+};
+
+const restaurant: MapIcon = {
+  id: 'restaurant',
+  name: 'Restaurant',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M11 9H9V2H7v7H5V2H3v7c0 2.12 1.66 3.84 3.75 3.97V22h2.5v-9.03C11.34 12.84 13 11.12 13 9V2h-2v7zm5-3v8h2.5v8H21V2c-2.76 0-5 2.24-5 4z"/></svg>`,
+};
+
+const school: MapIcon = {
+  id: 'school',
+  name: 'School',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"/></svg>`,
+};
+
+const shopping: MapIcon = {
+  id: 'shopping',
+  name: 'Shopping',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2zM1 2v2h2l3.6 7.59-1.35 2.45c-.16.28-.25.61-.25.96C5 16.1 5.9 17 7 17h12v-2H7.42c-.14 0-.25-.11-.25-.25l.03-.12.9-1.63h7.45c.75 0 1.41-.41 1.75-1.03l3.58-6.49A1 1 0 0 0 20 4H5.21l-.94-2H1zm16 16c-1.1 0-1.99.9-1.99 2s.89 2 1.99 2 2-.9 2-2-.9-2-2-2z"/></svg>`,
+};
+
+// ─── Nature ───────────────────────────────────────────────────────────────────
+
+const park: MapIcon = {
+  id: 'park',
+  name: 'Park',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M17 12h2L12 2 5 12h2l-3 6h7v4h2v-4h7l-3-6z"/></svg>`,
+};
+
+// ─── Status ───────────────────────────────────────────────────────────────────
+
+const warning: MapIcon = {
+  id: 'warning',
+  name: 'Warning',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>`,
+};
+
+const check: MapIcon = {
+  id: 'check',
+  name: 'Check',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>`,
+};
+
+const factory: MapIcon = {
+  id: 'factory',
+  name: 'Factory',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M22 22H2V10l7-3v2l5-3v3l8-4v17z"/></svg>`,
+};
+
+const cross: MapIcon = {
+  id: 'cross',
+  name: 'Cross',
+  svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="FILL_COLOR" stroke="STROKE_COLOR" stroke-width="STROKE_WIDTH"><path d="M9 2v7H2v6h7v7h6v-7h7V9h-7V2H9z"/></svg>`,
+};
+
+// ─── Exports ──────────────────────────────────────────────────────────────────
+
+export const ALL_BUILT_IN_ICONS: MapIcon[] = [
+  pin, circle, square, diamond, star, triangle, cross, home,
+  airport, ship, truck,
+  hospital, restaurant, school, shopping,
+  park,
+  warning, check, factory,
+];
+
+export const getBuiltInIconById = (id: string): MapIcon | undefined =>
+  ALL_BUILT_IN_ICONS.find((icon) => icon.id === id);
+
+export const DEFAULT_ICON_ID = 'pin';
+
+export const DEFAULT_ICON_FILL_COLOR = '#2196F3';
+export const DEFAULT_ICON_STROKE_COLOR = '#FFFFFF';
+export const DEFAULT_ICON_STROKE_WIDTH = 1;
+
+/**
+ * Apply fill and stroke colors to an SVG template.
+ * Supports two styles:
+ *   filled  – shape filled with fillColor, outlined with strokeColor
+ *   outline – shape has no fill (transparent), outlined with strokeColor
+ */
+export const applyIconColors = (
+  svgTemplate: string,
+  fillColor: string,
+  strokeColor: string,
+  style: 'filled' | 'outline' = 'filled'
+): string => {
+  const effectiveFill = style === 'outline' ? 'none' : fillColor;
+  return svgTemplate
+    .replace(/FILL_COLOR/g, effectiveFill)
+    .replace(/STROKE_COLOR/g, strokeColor)
+    .replace(/STROKE_WIDTH/g, String(DEFAULT_ICON_STROKE_WIDTH));
+};

--- a/public/components/map_icons/index.ts
+++ b/public/components/map_icons/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  MapIcon,
+  ALL_BUILT_IN_ICONS,
+  getBuiltInIconById,
+  DEFAULT_ICON_ID,
+  DEFAULT_ICON_FILL_COLOR,
+  DEFAULT_ICON_STROKE_COLOR,
+  DEFAULT_ICON_STROKE_WIDTH,
+  applyIconColors,
+} from './default_icons';

--- a/public/model/documentLayerFunctions.icon.test.ts
+++ b/public/model/documentLayerFunctions.icon.test.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DocumentLayerFunctions } from './documentLayerFunctions';
+import { MaplibreRef } from './layersFunctions';
+import { DocumentLayerSpecification } from './mapLayerType';
+import { DASHBOARDS_MAPS_LAYER_TYPE, LAYER_VISIBILITY } from '../../common';
+
+// Mock Image to make loadIconImage work in tests
+class MockImage {
+  width: number = 0;
+  height: number = 0;
+  src: string = '';
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(width?: number, height?: number) {
+    if (width) this.width = width;
+    if (height) this.height = height;
+    // Trigger onload asynchronously
+    setTimeout(() => {
+      if (this.onload) this.onload();
+    }, 0);
+  }
+}
+
+// @ts-ignore
+global.Image = MockImage;
+
+const createMockMaplibre = () => ({
+  addSource: jest.fn(),
+  getSource: jest.fn().mockReturnValue(null),
+  addLayer: jest.fn(),
+  getLayer: jest.fn().mockReturnValue(undefined),
+  removeLayer: jest.fn(),
+  getStyle: jest.fn().mockReturnValue({ layers: [] }),
+  setLayoutProperty: jest.fn(),
+  setPaintProperty: jest.fn(),
+  setLayerZoomRange: jest.fn(),
+  hasImage: jest.fn().mockReturnValue(false),
+  addImage: jest.fn(),
+});
+
+const createBaseDocumentLayerConfig = (styleOverrides?: any): DocumentLayerSpecification => ({
+  name: 'Test Layer',
+  id: 'test-layer-id',
+  description: 'Test document layer',
+  type: DASHBOARDS_MAPS_LAYER_TYPE.DOCUMENTS,
+  zoomRange: [0, 22],
+  opacity: 70,
+  visibility: LAYER_VISIBILITY.VISIBLE,
+  source: {
+    indexPatternRefName: 'test-index',
+    indexPatternId: 'test-index-id',
+    geoFieldType: 'geo_point',
+    geoFieldName: 'location',
+    documentRequestNumber: 1000,
+    showTooltips: false,
+    tooltipFields: [],
+    useGeoBoundingBoxFilter: true,
+    filters: [],
+    applyGlobalFilters: true,
+  },
+  style: {
+    fillColor: '#ff0000',
+    borderColor: '#000000',
+    borderThickness: 1,
+    markerSize: 5,
+    markerType: 'marker',
+    ...styleOverrides,
+  },
+});
+
+const sampleData = [
+  {
+    _source: {
+      location: { lat: 40.7128, lon: -74.006 },
+    },
+  },
+];
+
+describe('DocumentLayerFunctions with icon support', () => {
+  let mockMap: ReturnType<typeof createMockMaplibre>;
+  let maplibreRef: MaplibreRef;
+
+  beforeEach(() => {
+    mockMap = createMockMaplibre();
+    maplibreRef = {
+      current: mockMap as any,
+    };
+    jest.clearAllMocks();
+  });
+
+  describe('marker mode (default)', () => {
+    it('should add a circle layer when markerType is marker', () => {
+      const layerConfig = createBaseDocumentLayerConfig();
+
+      DocumentLayerFunctions.render(maplibreRef, layerConfig, sampleData, undefined);
+
+      // Should add source (getSource returns null so addSource is called)
+      expect(mockMap.addSource).toHaveBeenCalled();
+
+      // Should add a circle layer
+      expect(mockMap.addLayer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'circle',
+        })
+      );
+    });
+
+    it('should not add an icon layer when markerType is marker', () => {
+      const layerConfig = createBaseDocumentLayerConfig();
+
+      DocumentLayerFunctions.render(maplibreRef, layerConfig, sampleData, undefined);
+
+      // Should not have added a symbol layer with icon
+      const addLayerCalls = mockMap.addLayer.mock.calls;
+      const iconCalls = addLayerCalls.filter(
+        (call: any[]) => call[0].type === 'symbol' && call[0].id?.includes('-icon')
+      );
+      expect(iconCalls.length).toBe(0);
+    });
+  });
+
+  describe('icon mode', () => {
+    it('should not add a circle layer when markerType is icon', async () => {
+      const layerConfig = createBaseDocumentLayerConfig({
+        markerType: 'icon',
+        iconConfig: {
+          iconId: 'pin',
+          iconSize: 24,
+        },
+      });
+
+      DocumentLayerFunctions.render(maplibreRef, layerConfig, sampleData, undefined);
+
+      // Wait for async icon loading
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Should NOT have added a circle layer
+      const addLayerCalls = mockMap.addLayer.mock.calls;
+      const circleCalls = addLayerCalls.filter(
+        (call: any[]) => call[0].type === 'circle'
+      );
+      expect(circleCalls.length).toBe(0);
+    });
+
+    it('should add an icon (symbol) layer when markerType is icon', async () => {
+      const layerConfig = createBaseDocumentLayerConfig({
+        markerType: 'icon',
+        iconConfig: {
+          iconId: 'pin',
+          iconSize: 24,
+        },
+      });
+
+      DocumentLayerFunctions.render(maplibreRef, layerConfig, sampleData, undefined);
+
+      // Wait for async icon loading
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Should have loaded the image
+      expect(mockMap.addImage).toHaveBeenCalled();
+
+      // Should add a symbol layer with icon
+      expect(mockMap.addLayer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'test-layer-id-icon',
+          type: 'symbol',
+        })
+      );
+    });
+  });
+});

--- a/public/model/documentLayerFunctions.ts
+++ b/public/model/documentLayerFunctions.ts
@@ -21,6 +21,32 @@ import {
   createDocumentSymbolLayerSpecification,
 } from './map/layer_operations';
 import { getMaplibreAboveLayerId, MaplibreRef } from './layersFunctions';
+import {
+  getBuiltInIconById,
+  DEFAULT_ICON_ID,
+  DEFAULT_ICON_FILL_COLOR,
+  DEFAULT_ICON_STROKE_COLOR,
+  applyIconColors,
+} from '../components/map_icons';
+
+/**
+ * Resolve the final colored SVG string for a given layer's icon config.
+ * Built-in icons have fill/stroke colors applied via template substitution.
+ * Custom icons use the stored inline SVG as-is.
+ */
+const resolveIconSvg = (layerConfig: DocumentLayerSpecification): string | undefined => {
+  const iconConfig = layerConfig.style.iconConfig;
+  const iconId = iconConfig?.iconId || DEFAULT_ICON_ID;
+  const fillColor = iconConfig?.fillColor || DEFAULT_ICON_FILL_COLOR;
+  const strokeColor = iconConfig?.strokeColor || DEFAULT_ICON_STROKE_COLOR;
+  const iconStyle = iconConfig?.iconStyle || 'filled';
+
+  const builtIn = getBuiltInIconById(iconId);
+  if (builtIn) {
+    return applyIconColors(builtIn.svg, fillColor, strokeColor, iconStyle);
+  }
+  return iconConfig?.svg;
+};
 
 // https://opensearch.org/docs/1.3/opensearch/supported-field-types/geo-shape
 const openSearchGeoJSONMap = new Map<string, string>([
@@ -117,6 +143,204 @@ const getLayerSource = (data: any, layerConfig: DocumentLayerSpecification) => {
   };
 };
 
+/**
+ * Get the icon layer ID for a given source layer
+ */
+const getIconLayerId = (sourceId: string) => `${sourceId}-icon`;
+
+/**
+ * Check if icon mode is enabled for a layer
+ */
+const isIconMode = (layerConfig: DocumentLayerSpecification): boolean => {
+  return layerConfig.style?.markerType === 'icon';
+};
+
+/**
+ * Convert an SVG string to a data URL for image loading.
+ * data: URLs are allowed by the CSP img-src directive.
+ * Security note: The SVG has been validated and sanitized before reaching this point.
+ * Additionally, when loaded as an <img> src, the browser treats the SVG as a
+ * static image — scripts and external references are not executed in this context.
+ */
+const svgToDataUrl = (svg: string): string => {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+};
+
+/**
+ * Load an icon image into the maplibre instance.
+ * The SVG is loaded via a data URL into an <img> element. When used as img.src,
+ * browsers parse the SVG in a restricted context where scripts don't execute and
+ * external resource loading is blocked — this is inherent browser security for
+ * images loaded via data URLs.
+ */
+const loadIconImage = (
+  maplibreInstance: any,
+  imageId: string,
+  svg: string,
+  size: number = 24
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    // If image already exists, resolve immediately
+    if (maplibreInstance.hasImage(imageId)) {
+      resolve();
+      return;
+    }
+
+    const img = new Image(size, size);
+    img.onload = () => {
+      try {
+        if (!maplibreInstance.hasImage(imageId)) {
+          maplibreInstance.addImage(imageId, img, { sdf: false });
+        }
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    };
+    img.onerror = () => {
+      reject(new Error(`Failed to load icon image: ${imageId}`));
+    };
+    img.src = svgToDataUrl(svg);
+  });
+};
+
+/**
+ * Build a unique maplibre image ID that includes color/style so different
+ * color variants are stored as separate images in the maplibre image registry.
+ */
+const buildImageId = (layerConfig: DocumentLayerSpecification): string => {
+  const iconConfig = layerConfig.style.iconConfig;
+  const iconId = iconConfig?.iconId || DEFAULT_ICON_ID;
+  const fillColor = (iconConfig?.fillColor || DEFAULT_ICON_FILL_COLOR).replace('#', '');
+  const strokeColor = (iconConfig?.strokeColor || DEFAULT_ICON_STROKE_COLOR).replace('#', '');
+  const iconStyle = iconConfig?.iconStyle || 'filled';
+  return `map-icon-${iconId}-${iconStyle}-${fillColor}-${strokeColor}`;
+};
+
+/**
+ * Ensure the icon is loaded in maplibre before adding the layer.
+ * If the icon is already loaded, adds the layer immediately.
+ */
+const ensureIconAndAddLayer = (
+  maplibreInstance: any,
+  layerConfig: DocumentLayerSpecification
+) => {
+  const iconConfig = layerConfig.style.iconConfig;
+  const iconSvg = resolveIconSvg(layerConfig);
+  if (!iconSvg) return;
+
+  const imageId = buildImageId(layerConfig);
+  loadIconImage(maplibreInstance, imageId, iconSvg, iconConfig?.iconSize || 24)
+    .then(() => {
+      addIconLayer(maplibreInstance, layerConfig, imageId);
+    })
+    .catch(() => {
+      // Fallback to circle layer if icon load fails
+      addCircleLayer(maplibreInstance, {
+        fillColor: layerConfig.style?.fillColor,
+        maxZoom: layerConfig.zoomRange[1],
+        minZoom: layerConfig.zoomRange[0],
+        opacity: layerConfig.opacity,
+        outlineColor: layerConfig.style?.borderColor,
+        radius: layerConfig.style?.markerSize,
+        sourceId: layerConfig.id,
+        visibility: layerConfig.visibility,
+        width: layerConfig.style?.borderThickness,
+      });
+    });
+};
+
+/**
+ * Add an icon (symbol) layer to the map for document point rendering
+ */
+const addIconLayer = (
+  maplibreInstance: any,
+  layerConfig: DocumentLayerSpecification,
+  imageId: string
+) => {
+  const iconConfig = layerConfig.style.iconConfig;
+  const iconSize = iconConfig?.iconSize || 24;
+  const iconLayerId = getIconLayerId(layerConfig.id);
+
+  // Don't add if layer already exists
+  if (maplibreInstance.getLayer(iconLayerId)) {
+    return;
+  }
+
+  const layerSpec: any = {
+    id: iconLayerId,
+    type: 'symbol',
+    source: layerConfig.id,
+    filter: ['==', '$type', 'Point'],
+    layout: {
+      'icon-image': imageId,
+      'icon-size': iconSize / 24, // normalize to base size
+      'icon-allow-overlap': true,
+      'icon-ignore-placement': false,
+      visibility: layerConfig.visibility,
+    },
+    paint: {
+      'icon-opacity': layerConfig.opacity / 100,
+    },
+  };
+
+  maplibreInstance.addLayer(layerSpec);
+  maplibreInstance.setLayerZoomRange(iconLayerId, layerConfig.zoomRange[0], layerConfig.zoomRange[1]);
+};
+
+/**
+ * Update an existing icon layer
+ */
+const updateIconLayer = (
+  maplibreInstance: any,
+  layerConfig: DocumentLayerSpecification,
+  imageId: string
+) => {
+  const iconConfig = layerConfig.style.iconConfig;
+  const iconSize = iconConfig?.iconSize || 24;
+  const iconLayerId = getIconLayerId(layerConfig.id);
+
+  maplibreInstance.setLayoutProperty(iconLayerId, 'icon-image', imageId);
+  maplibreInstance.setLayoutProperty(iconLayerId, 'icon-size', iconSize / 24);
+  maplibreInstance.setLayoutProperty(iconLayerId, 'visibility', layerConfig.visibility);
+  maplibreInstance.setPaintProperty(iconLayerId, 'icon-opacity', layerConfig.opacity / 100);
+  maplibreInstance.setLayerZoomRange(iconLayerId, layerConfig.zoomRange[0], layerConfig.zoomRange[1]);
+};
+
+/**
+ * Check if an icon layer exists
+ */
+const hasIconLayer = (maplibreInstance: any, sourceId: string): boolean => {
+  return !!maplibreInstance.getLayer(getIconLayerId(sourceId));
+};
+
+/**
+ * Remove an icon layer
+ */
+const removeIconLayer = (maplibreInstance: any, sourceId: string) => {
+  const iconLayerId = getIconLayerId(sourceId);
+  if (maplibreInstance.getLayer(iconLayerId)) {
+    maplibreInstance.removeLayer(iconLayerId);
+  }
+};
+
+/**
+ * Check if a circle layer exists for the given source
+ */
+const hasCircleLayer = (maplibreInstance: any, sourceId: string): boolean => {
+  return !!maplibreInstance.getLayer(`${sourceId}-circle`);
+};
+
+/**
+ * Remove circle layer
+ */
+const removeCircleLayer = (maplibreInstance: any, sourceId: string) => {
+  const circleLayerId = `${sourceId}-circle`;
+  if (maplibreInstance.getLayer(circleLayerId)) {
+    maplibreInstance.removeLayer(circleLayerId);
+  }
+};
+
 const addNewLayer = (
   layerConfig: DocumentLayerSpecification,
   maplibreRef: MaplibreRef,
@@ -128,21 +352,39 @@ const addNewLayer = (
     return;
   }
   const source = getLayerSource(data, layerConfig);
-  maplibreInstance.addSource(layerConfig.id, {
-    type: 'geojson',
-    data: source,
-  });
-  addCircleLayer(maplibreInstance, {
-    fillColor: layerConfig.style?.fillColor,
-    maxZoom: layerConfig.zoomRange[1],
-    minZoom: layerConfig.zoomRange[0],
-    opacity: layerConfig.opacity,
-    outlineColor: layerConfig.style?.borderColor,
-    radius: layerConfig.style?.markerSize,
-    sourceId: layerConfig.id,
-    visibility: layerConfig.visibility,
-    width: layerConfig.style?.borderThickness,
-  });
+
+  // Guard: source may already exist if render is called while async icon loading is in progress
+  if (!maplibreInstance.getSource(layerConfig.id)) {
+    maplibreInstance.addSource(layerConfig.id, {
+      type: 'geojson',
+      data: source,
+    });
+  } else {
+    // Update existing source data
+    const existingSource = maplibreInstance.getSource(layerConfig.id);
+    if (existingSource) {
+      // @ts-ignore
+      existingSource.setData(source);
+    }
+  }
+
+  if (isIconMode(layerConfig)) {
+    // Load icon and add symbol layer
+    ensureIconAndAddLayer(maplibreInstance, layerConfig);
+  } else {
+    addCircleLayer(maplibreInstance, {
+      fillColor: layerConfig.style?.fillColor,
+      maxZoom: layerConfig.zoomRange[1],
+      minZoom: layerConfig.zoomRange[0],
+      opacity: layerConfig.opacity,
+      outlineColor: layerConfig.style?.borderColor,
+      radius: layerConfig.style?.markerSize,
+      sourceId: layerConfig.id,
+      visibility: layerConfig.visibility,
+      width: layerConfig.style?.borderThickness,
+    });
+  }
+
   const geoFieldType = getGeoFieldType(layerConfig);
   if (geoFieldType === 'geo_shape') {
     addLineLayer(maplibreInstance, {
@@ -179,17 +421,74 @@ const updateLayer = (
       // @ts-ignore
       dataSource.setData(getLayerSource(data, layerConfig));
     }
-    updateCircleLayer(maplibreInstance, {
-      fillColor: layerConfig.style.fillColor,
-      maxZoom: layerConfig.zoomRange[1],
-      minZoom: layerConfig.zoomRange[0],
-      opacity: layerConfig.opacity,
-      outlineColor: layerConfig.style.borderColor,
-      radius: layerConfig.style?.markerSize,
-      sourceId: layerConfig.id,
-      visibility: layerConfig.visibility,
-      width: layerConfig.style.borderThickness,
-    });
+
+    if (isIconMode(layerConfig)) {
+      // Remove circle layer if it exists (switching from marker to icon mode)
+      if (hasCircleLayer(maplibreInstance, layerConfig.id)) {
+        removeCircleLayer(maplibreInstance, layerConfig.id);
+      }
+
+      const iconConfig = layerConfig.style.iconConfig;
+      const iconSvg = resolveIconSvg(layerConfig);
+      const imageId = buildImageId(layerConfig);
+
+      if (iconSvg) {
+        loadIconImage(maplibreInstance, imageId, iconSvg, iconConfig?.iconSize || 24)
+          .then(() => {
+            if (hasIconLayer(maplibreInstance, layerConfig.id)) {
+              updateIconLayer(maplibreInstance, layerConfig, imageId);
+            } else {
+              addIconLayer(maplibreInstance, layerConfig, imageId);
+            }
+          })
+          .catch(() => {
+            // Fallback: icon load failed, re-add circle layer
+            addCircleLayer(maplibreInstance, {
+              fillColor: layerConfig.style?.fillColor,
+              maxZoom: layerConfig.zoomRange[1],
+              minZoom: layerConfig.zoomRange[0],
+              opacity: layerConfig.opacity,
+              outlineColor: layerConfig.style?.borderColor,
+              radius: layerConfig.style?.markerSize,
+              sourceId: layerConfig.id,
+              visibility: layerConfig.visibility,
+              width: layerConfig.style?.borderThickness,
+            });
+          });
+      }
+    } else {
+      // Remove icon layer if switching back to marker mode
+      if (hasIconLayer(maplibreInstance, layerConfig.id)) {
+        removeIconLayer(maplibreInstance, layerConfig.id);
+      }
+
+      if (hasCircleLayer(maplibreInstance, layerConfig.id)) {
+        updateCircleLayer(maplibreInstance, {
+          fillColor: layerConfig.style.fillColor,
+          maxZoom: layerConfig.zoomRange[1],
+          minZoom: layerConfig.zoomRange[0],
+          opacity: layerConfig.opacity,
+          outlineColor: layerConfig.style.borderColor,
+          radius: layerConfig.style?.markerSize,
+          sourceId: layerConfig.id,
+          visibility: layerConfig.visibility,
+          width: layerConfig.style.borderThickness,
+        });
+      } else {
+        addCircleLayer(maplibreInstance, {
+          fillColor: layerConfig.style?.fillColor,
+          maxZoom: layerConfig.zoomRange[1],
+          minZoom: layerConfig.zoomRange[0],
+          opacity: layerConfig.opacity,
+          outlineColor: layerConfig.style?.borderColor,
+          radius: layerConfig.style?.markerSize,
+          sourceId: layerConfig.id,
+          visibility: layerConfig.visibility,
+          width: layerConfig.style?.borderThickness,
+        });
+      }
+    }
+
     const geoFieldType = getGeoFieldType(layerConfig);
     if (geoFieldType === 'geo_shape') {
       updateLineLayer(maplibreInstance, {

--- a/public/model/icon_functions.test.ts
+++ b/public/model/icon_functions.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ALL_BUILT_IN_ICONS,
+  getBuiltInIconById,
+  DEFAULT_ICON_ID,
+} from '../components/map_icons';
+
+describe('Default Icons', () => {
+  it('should have at least 10 built-in icons', () => {
+    expect(ALL_BUILT_IN_ICONS.length).toBeGreaterThan(10);
+  });
+
+  it('should return an icon by id', () => {
+    const icon = getBuiltInIconById('pin');
+    expect(icon).toBeDefined();
+    expect(icon!.name).toBe('Pin');
+    expect(icon!.svg).toContain('<svg');
+  });
+
+  it('should return undefined for unknown icon id', () => {
+    const icon = getBuiltInIconById('nonexistent-icon');
+    expect(icon).toBeUndefined();
+  });
+
+  it('should have a valid DEFAULT_ICON_ID that resolves', () => {
+    const icon = getBuiltInIconById(DEFAULT_ICON_ID);
+    expect(icon).toBeDefined();
+  });
+
+  it('all icons should have required fields', () => {
+    ALL_BUILT_IN_ICONS.forEach((icon) => {
+      expect(icon.id).toBeTruthy();
+      expect(icon.name).toBeTruthy();
+      expect(icon.svg).toBeTruthy();
+    });
+  });
+
+  it('all icons should have unique ids', () => {
+    const ids = ALL_BUILT_IN_ICONS.map((icon) => icon.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('all SVGs should be valid SVG template strings', () => {
+    ALL_BUILT_IN_ICONS.forEach((icon) => {
+      expect(icon.svg).toContain('<svg');
+      expect(icon.svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+      expect(icon.svg).toContain('</svg>');
+      expect(icon.svg).toContain('FILL_COLOR');
+      expect(icon.svg).toContain('STROKE_COLOR');
+    });
+  });
+});

--- a/public/model/mapLayerType.ts
+++ b/public/model/mapLayerType.ts
@@ -53,6 +53,15 @@ export type DocumentLayerSpecification = AbstractLayerSpecification & {
     borderColor: string;
     borderThickness: number;
     markerSize: number;
+    markerType?: 'marker' | 'icon';
+    iconConfig?: {
+      iconId: string;
+      iconSize?: number;
+      iconStyle?: 'filled' | 'outline';
+      fillColor?: string;
+      strokeColor?: string;
+      svg?: string;
+    };
     label?: {
       enabled: boolean;
       textByFixed: string;

--- a/public/utils/getIntialConfig.ts
+++ b/public/utils/getIntialConfig.ts
@@ -68,6 +68,7 @@ export const getLayerConfigMap = () => ({
       ...getStyleColor(),
       borderThickness: DOCUMENTS_DEFAULT_MARKER_BORDER_THICKNESS,
       markerSize: DOCUMENTS_DEFAULT_MARKER_SIZE,
+      markerType: 'marker',
       label: {
         enabled: DOCUMENTS_DEFAULT_LABEL_ENABLES,
         textByFixed: '',

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -22,8 +22,8 @@ import {
 } from './types';
 import { createGeospatialCluster } from './clusters';
 import { GeospatialService, OpensearchService } from './services';
-import { geospatial, opensearch, statsRoute } from '../server/routes';
-import { mapSavedObjectsType } from './saved_objects';
+import { geospatial, opensearch, statsRoute, iconRoute } from '../server/routes';
+import { mapSavedObjectsType, mapIconSavedObjectsType } from './saved_objects';
 import { capabilitiesProvider } from './saved_objects/capabilities_provider';
 import { ConfigSchema } from '../common/config';
 import GeospatialPlugin from './clusters/geospatial_plugin';
@@ -68,9 +68,11 @@ export class CustomImportMapPlugin
     geospatial(geospatialService, router);
     opensearch(opensearchService, router);
     statsRoute(router, this.logger);
+    iconRoute(router);
 
     // Register saved object types
     core.savedObjects.registerType(mapSavedObjectsType);
+    core.savedObjects.registerType(mapIconSavedObjectsType);
 
     // Register capabilities
     core.capabilities.registerProvider(capabilitiesProvider);

--- a/server/routes/icon_router.ts
+++ b/server/routes/icon_router.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import {
+  IOpenSearchDashboardsResponse,
+  IRouter,
+} from '../../../../src/core/server';
+import { APP_API } from '../../common';
+import { MAP_ICON_SAVED_OBJECT_TYPE } from '../saved_objects';
+
+const ICON_API_PATH = `${APP_API}/icons`;
+const MAX_ICON_SVG_SIZE = 100 * 1024; // 100KB max for SVG content
+
+/**
+ * Server-side SVG validation.
+ * Minimal checks — the security boundary is client-side rendering via <img> data URL,
+ * which inherently prevents script execution, external resource loading, and DOM access.
+ * Server-side validation just ensures we're storing valid SVG content.
+ */
+function validateSvgContent(svg: string): { valid: boolean; reason?: string } {
+  if (!svg.toLowerCase().includes('<svg')) {
+    return { valid: false, reason: 'Content is not a valid SVG' };
+  }
+  return { valid: true };
+}
+
+export function iconRoute(router: IRouter) {
+  // Create a new custom icon
+  router.post(
+    {
+      path: ICON_API_PATH,
+      validate: {
+        body: schema.object({
+          name: schema.string({ minLength: 1, maxLength: 100 }),
+          svg: schema.string({ minLength: 1, maxLength: MAX_ICON_SVG_SIZE }),
+        }),
+      },
+    },
+    async (context, request, response): Promise<IOpenSearchDashboardsResponse<any>> => {
+      try {
+        const { name, svg } = request.body;
+
+        // Server-side SVG validation — fast reject obvious attacks
+        const validation = validateSvgContent(svg);
+        if (!validation.valid) {
+          return response.custom({
+            statusCode: 400,
+            body: validation.reason || 'Invalid SVG content',
+          });
+        }
+
+        const savedObjectsClient = context.core.savedObjects.client;
+
+        const savedObject = await savedObjectsClient.create(MAP_ICON_SAVED_OBJECT_TYPE, {
+          name,
+          svg,
+        });
+
+        return response.ok({
+          body: {
+            id: savedObject.id,
+            ...savedObject.attributes,
+          },
+        });
+      } catch (error: any) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+
+  // Get all custom icons (metadata only — SVG fetched individually via GET /{id})
+  router.get(
+    {
+      path: ICON_API_PATH,
+      validate: {},
+    },
+    async (context, request, response): Promise<IOpenSearchDashboardsResponse<any>> => {
+      try {
+        const savedObjectsClient = context.core.savedObjects.client;
+
+        const findResponse = await savedObjectsClient.find({
+          type: MAP_ICON_SAVED_OBJECT_TYPE,
+          perPage: 100,
+        });
+
+        const icons = findResponse.saved_objects.map((obj) => ({
+          id: obj.id,
+          name: (obj.attributes as any).name,
+        }));
+
+        return response.ok({
+          body: { icons },
+        });
+      } catch (error: any) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+
+  // Get a single icon by ID
+  router.get(
+    {
+      path: `${ICON_API_PATH}/{id}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<IOpenSearchDashboardsResponse<any>> => {
+      try {
+        const savedObjectsClient = context.core.savedObjects.client;
+        const savedObject = await savedObjectsClient.get(
+          MAP_ICON_SAVED_OBJECT_TYPE,
+          request.params.id
+        );
+
+        return response.ok({
+          body: {
+            id: savedObject.id,
+            ...savedObject.attributes,
+          },
+        });
+      } catch (error: any) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+
+  // Delete an icon
+  router.delete(
+    {
+      path: `${ICON_API_PATH}/{id}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<IOpenSearchDashboardsResponse<any>> => {
+      try {
+        const savedObjectsClient = context.core.savedObjects.client;
+        const { id } = request.params;
+
+        await savedObjectsClient.delete(MAP_ICON_SAVED_OBJECT_TYPE, id);
+
+        return response.ok({
+          body: { success: true },
+        });
+      } catch (error: any) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,5 +6,6 @@
 import geospatial from './geospatial';
 import opensearch from './opensearch';
 import { statsRoute } from './stats_router';
+import { iconRoute } from './icon_router';
 
-export { geospatial, opensearch, statsRoute };
+export { geospatial, opensearch, statsRoute, iconRoute };

--- a/server/saved_objects/index.ts
+++ b/server/saved_objects/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { mapSavedObjectsType } from './map_saved_object';
+export { mapIconSavedObjectsType, MAP_ICON_SAVED_OBJECT_TYPE } from './map_icon_saved_object';

--- a/server/saved_objects/map_icon_saved_object.test.ts
+++ b/server/saved_objects/map_icon_saved_object.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mapIconSavedObjectsType, MAP_ICON_SAVED_OBJECT_TYPE } from './map_icon_saved_object';
+
+describe('mapIconSavedObjectsType', () => {
+  it('should have the correct type name', () => {
+    expect(mapIconSavedObjectsType.name).toBe('map-icon');
+    expect(MAP_ICON_SAVED_OBJECT_TYPE).toBe('map-icon');
+  });
+
+  it('should not be hidden', () => {
+    expect(mapIconSavedObjectsType.hidden).toBe(false);
+  });
+
+  it('should be single namespace (tenant-scoped)', () => {
+    expect(mapIconSavedObjectsType.namespaceType).toBe('single');
+  });
+
+  it('should be importable and exportable', () => {
+    expect(mapIconSavedObjectsType.management?.importableAndExportable).toBe(true);
+  });
+
+  it('should use name as default search field', () => {
+    expect(mapIconSavedObjectsType.management?.defaultSearchField).toBe('name');
+  });
+
+  it('should have correct mappings', () => {
+    const properties = mapIconSavedObjectsType.mappings?.properties;
+    expect(properties).toHaveProperty('name');
+    expect(properties).toHaveProperty('svg');
+  });
+
+  it('getTitle should return the icon name', () => {
+    const mockObj = {
+      id: 'test-id',
+      type: 'map-icon',
+      attributes: { name: 'My Custom Icon' },
+      references: [],
+    };
+    const title = mapIconSavedObjectsType.management?.getTitle?.(mockObj);
+    expect(title).toBe('My Custom Icon');
+  });
+
+  it('getInAppUrl should return correct path', () => {
+    const mockObj = {
+      id: 'test-icon-id',
+      type: 'map-icon',
+      attributes: { name: 'Test Icon' },
+      references: [],
+    };
+    const result = mapIconSavedObjectsType.management?.getInAppUrl?.(mockObj);
+    expect(result?.path).toContain('/app/maps-dashboards#/icons/test-icon-id');
+  });
+});

--- a/server/saved_objects/map_icon_saved_object.ts
+++ b/server/saved_objects/map_icon_saved_object.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectsType } from 'opensearch-dashboards/server';
+
+export const MAP_ICON_SAVED_OBJECT_TYPE = 'map-icon';
+
+export const mapIconSavedObjectsType: SavedObjectsType = {
+  name: MAP_ICON_SAVED_OBJECT_TYPE,
+  hidden: false,
+  namespaceType: 'single',
+  management: {
+    defaultSearchField: 'name',
+    importableAndExportable: true,
+    getTitle(obj: any) {
+      return obj.attributes.name;
+    },
+    getInAppUrl(obj: any) {
+      return {
+        path: `/app/maps-dashboards#/icons/${encodeURIComponent(obj.id)}`,
+        uiCapabilitiesPath: 'map.show',
+      };
+    },
+  },
+  mappings: {
+    properties: {
+      name: { type: 'text' },
+      svg: { type: 'text', index: false },
+    },
+  },
+  migrations: {},
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,10 +356,10 @@ murmurhash-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
   integrity sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==
 
-nanoid@^5.0.9:
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.9.tgz#aac959acf7d685269fb1be7f70a90d9db0848948"
-  integrity sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==
+nanoid@^5.0.9, nanoid@^5.1.16:
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.16.tgz#fe345c0a1f9007c32fbb5c139e1208bfd3f41ef7"
+  integrity sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
 
 pbf@^3.2.1, pbf@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
### Description
 Add the ability to style document layer points as icons instead of plain circle markers. Users can choose from built-in icons with customizable fill/outline colors and style (filled or outline), or upload their own SVG icons.

  Changes:
  - Add marker/icon toggle to document layer style panel
  - Add built-in icon set with color template system (FILL_COLOR, STROKE_COLOR)
  - Add icon picker component with built-in and custom tabs
  - Add custom SVG upload with client-side and server-side security validation
  - Add map-icon saved object type for persisting custom icons
  - Add CRUD API routes (POST, GET, DELETE) for custom icons
  - Update DocumentLayerFunctions to render icons via maplibre symbol layers
  - Extend DocumentLayerSpecification.style with markerType and iconConfig
  - Add unit tests for icon set, rendering logic, and saved object type

  Custom icons are stored as saved objects (shared across maps). When selected, the SVG is stored inline in the layer config so icons always render even if the saved object is later deleted.


https://github.com/user-attachments/assets/822ad0c0-c616-4cf9-a78b-3665f38a2311



### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/568
https://github.com/opensearch-project/dashboards-maps/issues/858

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
