### PR TITLE
fix: enforce layer order after late tile loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 ### Bug Fixes
+* fix: enforce layer order after late tile loads ([#860](https://github.com/opensearch-project/dashboards-maps/pull/860))
 
 ### Infrastructure
 

--- a/public/components/map_container/map_container.tsx
+++ b/public/components/map_container/map_container.tsx
@@ -211,9 +211,12 @@ export const MapContainer = ({
       } else {
         renderDataLayers(layers, mapState, services, maplibreRef, legendRef, dashboardProps);
         renderBaseLayers(layers, maplibreRef, services, onError);
-        // Because of async layer rendering, layers order is not guaranteed, so we need to order layers
-        // after all layers are rendered.
-        maplibreRef.current!.once('idle', orderLayersAfterRenderLoaded);
+        // Because of async layer rendering (e.g. raster basemap tiles loading after document
+        // layers), layer order is not guaranteed. Use on('idle') instead of once('idle') so
+        // that ordering is re-enforced each time the map settles, including after late tile
+        // loads. The orderLayers function skips reordering when the order is already correct,
+        // preventing infinite repaint loops.
+        maplibreRef.current!.on('idle', orderLayersAfterRenderLoaded);
       }
       setIsUpdatingLayerRender(false);
     }

--- a/public/model/layerRenderController.test.ts
+++ b/public/model/layerRenderController.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Map as Maplibre } from 'maplibre-gl';
+import { orderLayers } from './layerRenderController';
+import { MockMaplibreMap } from './map/__mocks__/map';
+import { MockLayer } from './map/__mocks__/layer';
+import { MapLayerSpecification } from './mapLayerType';
+
+describe('orderLayers', () => {
+  const createMockMapLayer = (id: string): MapLayerSpecification => {
+    return { id } as MapLayerSpecification;
+  };
+
+  it('should reorder layers when maplibre layer order does not match dashboard-maps order', () => {
+    // Simulate: basemap layer is above document layer in maplibre (wrong order)
+    const basemapMbLayer = new MockLayer('basemap-layer-1');
+    const documentMbLayer = new MockLayer('document-layer-1-circle');
+    // maplibre has document layer first, then basemap on top (wrong for the user's desired order)
+    const mockMap = new MockMaplibreMap([documentMbLayer, basemapMbLayer]);
+
+    // Dashboard-maps layer order: basemap first (bottom), document layer second (top)
+    const mapLayers = [
+      createMockMapLayer('basemap-layer-1'),
+      createMockMapLayer('document-layer-1'),
+    ];
+
+    orderLayers(mapLayers, mockMap as unknown as Maplibre);
+
+    // After ordering, basemap should be below document layer
+    const orderedLayers = mockMap.getStyle().layers;
+    expect(orderedLayers[0].id).toBe('basemap-layer-1');
+    expect(orderedLayers[1].id).toBe('document-layer-1-circle');
+  });
+
+  it('should not call moveLayer when layers are already in correct order', () => {
+    // Simulate: layers are already in correct order
+    const basemapMbLayer = new MockLayer('basemap-layer-1');
+    const documentMbLayer = new MockLayer('document-layer-1-circle');
+    const mockMap = new MockMaplibreMap([basemapMbLayer, documentMbLayer]);
+
+    const moveLayerSpy = jest.spyOn(mockMap, 'moveLayer');
+
+    const mapLayers = [
+      createMockMapLayer('basemap-layer-1'),
+      createMockMapLayer('document-layer-1'),
+    ];
+
+    orderLayers(mapLayers, mockMap as unknown as Maplibre);
+
+    // moveLayer should not have been called since order is already correct
+    expect(moveLayerSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle multiple maplibre layers per dashboard-maps layer', () => {
+    // Document layers often have multiple maplibre layers (circle, line, fill, symbol)
+    const basemapMbLayer = new MockLayer('basemap-1');
+    const docCircle = new MockLayer('doc-1-circle');
+    const docLine = new MockLayer('doc-1-line');
+
+    // Wrong order: doc layers are below basemap
+    const mockMap = new MockMaplibreMap([docCircle, docLine, basemapMbLayer]);
+
+    const mapLayers = [
+      createMockMapLayer('basemap-1'),
+      createMockMapLayer('doc-1'),
+    ];
+
+    orderLayers(mapLayers, mockMap as unknown as Maplibre);
+
+    const orderedLayers = mockMap.getStyle().layers;
+    expect(orderedLayers[0].id).toBe('basemap-1');
+    expect(orderedLayers[1].id).toBe('doc-1-circle');
+    expect(orderedLayers[2].id).toBe('doc-1-line');
+  });
+
+  it('should handle case where no maplibre layers exist yet', () => {
+    const mockMap = new MockMaplibreMap([]);
+    const moveLayerSpy = jest.spyOn(mockMap, 'moveLayer');
+
+    const mapLayers = [
+      createMockMapLayer('basemap-1'),
+      createMockMapLayer('doc-1'),
+    ];
+
+    orderLayers(mapLayers, mockMap as unknown as Maplibre);
+
+    expect(moveLayerSpy).not.toHaveBeenCalled();
+  });
+});

--- a/public/model/layerRenderController.ts
+++ b/public/model/layerRenderController.ts
@@ -281,15 +281,38 @@ export const renderBaseLayers = (
   });
 };
 
-// Order maplibre layers based on the order of dashboard-maps layers
+// Order maplibre layers based on the order of dashboard-maps layers.
+// Skips reordering if the layers are already in the correct order to avoid
+// triggering unnecessary repaints (which could cause infinite idle event loops).
 export const orderLayers = (mapLayers: MapLayerSpecification[], maplibre: Maplibre): void => {
   const maplibreLayers = maplibre.getStyle().layers;
   if (!maplibreLayers) return;
+
+  // Build the expected order of managed layer IDs
+  const expectedOrder: string[] = [];
   mapLayers.forEach((layer) => {
     const layerId = layer.id;
     const mbLayers = maplibreLayers.filter((mbLayer) => mbLayer.id.includes(layerId));
-    mbLayers.forEach((mbLayer, index) => {
-      maplibre.moveLayer(mbLayer.id);
+    mbLayers.forEach((mbLayer) => {
+      expectedOrder.push(mbLayer.id);
     });
+  });
+
+  // Get the current order of only the managed layers (preserving relative order)
+  const currentOrder = maplibreLayers
+    .filter((mbLayer) => expectedOrder.includes(mbLayer.id))
+    .map((mbLayer) => mbLayer.id);
+
+  // If the order is already correct, do nothing to avoid triggering a repaint
+  if (
+    currentOrder.length === expectedOrder.length &&
+    currentOrder.every((id, index) => id === expectedOrder[index])
+  ) {
+    return;
+  }
+
+  // Reorder by moving each layer to the top in the expected sequence
+  expectedOrder.forEach((mbLayerId) => {
+    maplibre.moveLayer(mbLayerId);
   });
 };


### PR DESCRIPTION


### Description
The basemap could render above document layers when raster tiles arrived after the single once('idle') handler had already fired.

- Change once('idle') to on('idle') so ordering is re-enforced each time the map settles, including after late tile loads.
- Add a skip-if-correct guard to orderLayers to prevent infinite repaint loops when the order is already correct.
- Add unit tests for orderLayers.

### Issues Resolved
#853

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
